### PR TITLE
docs: comprehensive documentation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,235 @@
-# Lightning Agent Kit
+# Lightning Agent Tools
 
-A Claude Code plugin that gives AI agents the skills to operate on the Lightning
-Network — run nodes, send/receive payments, bake scoped credentials, and host
-paid API endpoints.
+AI agents can read documentation, write code, and orchestrate complex workflows,
+but they can't easily pay for things. Traditional payment rails require
+government IDs, bank accounts, and manual enrollment, none of which work for
+autonomous software. Lightning Agent Tools bridges this gap by giving agents
+native access to the [Lightning Network](https://lightning.network), a
+decentralized payment protocol capable of instant, high-volume transactions with
+no identity requirements.
 
-## Skills
+The toolkit consists of seven composable skills and an MCP server. Together they
+let an agent run a Lightning node, pay for resources on the web using the
+[L402](https://docs.lightning.engineering/the-lightning-network/l402) protocol,
+host its own paid API endpoints, manage scoped credentials, and query node state
+through the Model Context Protocol. The skills work with any agent framework
+that can execute shell commands: [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview),
+[Codex](https://openai.com/index/codex/), or your own tooling. The MCP server
+follows the [Model Context Protocol](https://modelcontextprotocol.io) standard
+and works with any compatible client. The security model defaults to a remote
+signer architecture that keeps private keys on a separate machine, away from the
+agent's runtime environment.
 
-| Skill | Description |
-|-------|-------------|
-| **lnd** | Install and run an lnd Lightning node. Defaults to watch-only mode with remote signer. |
-| **lightning-security-module** | Set up a remote signer node that holds private keys on a separate machine. |
-| **macaroon-bakery** | Bake least-privilege macaroons for scoped agent access. |
-| **lnget** | Lightning-native HTTP client with automatic L402 payment support. |
-| **aperture** | L402 reverse proxy for hosting paid API endpoints. |
-| **mcp-lnc** | MCP server for Lightning Node Connect — connects AI assistants to lnd via encrypted WebSocket tunnels. |
-| **commerce** | End-to-end agent commerce workflow (lnd + lnget + aperture). |
+## How It Works
+
+```mermaid
+graph TD
+    CC["Your Agent"] --> Skills
+
+    subgraph Skills["Skills"]
+        lnd["lnd<br/><i>run a Lightning node</i>"]
+        lsm["lightning-security-module<br/><i>remote signer</i>"]
+        mb["macaroon-bakery<br/><i>scoped credentials</i>"]
+        lg["lnget<br/><i>L402 HTTP client</i>"]
+        ap["aperture<br/><i>L402 reverse proxy</i>"]
+        mcp["mcp-lnc<br/><i>MCP server</i>"]
+        com["commerce<br/><i>buyer/seller workflows</i>"]
+    end
+
+    subgraph Runtime["Daemons & Tools"]
+        lnd_d["lnd daemon"]
+        signer_d["lnd signer"]
+        aperture_d["aperture proxy"]
+        lnget_d["lnget CLI"]
+        mcp_d["mcp-lnc-server"]
+    end
+
+    lnd --> lnd_d
+    lsm --> signer_d
+    lg --> lnget_d
+    ap --> aperture_d
+    mcp --> mcp_d
+
+    lnd_d <-->|"remote signing"| signer_d
+    lnget_d -->|"pays invoices"| lnd_d
+    aperture_d -->|"generates invoices"| lnd_d
+    mcp_d <-->|"LNC tunnel"| lnd_d
+
+    com -.-> lnd
+    com -.-> lg
+    com -.-> ap
+```
+
+The skills break down into three functional groups:
+
+**Payment infrastructure.** The `lnd` skill runs a Lightning node using the
+Neutrino light client (no full Bitcoin node required) with SQLite storage. The
+`lightning-security-module` sets up a remote signer to hold private keys on a
+separate machine. The `macaroon-bakery` bakes least-privilege credentials so
+agents only get the permissions they need.
+
+**Commerce.** The `lnget` skill installs a command-line HTTP client that handles
+L402 payments automatically. When it hits a 402 response, it pays the embedded
+Lightning invoice, caches the token, and retries. The `aperture` skill runs an
+L402 reverse proxy that gates access to a backend service behind Lightning
+invoices. The `commerce` skill ties these together into buyer and seller
+workflows.
+
+**Node access.** The `mcp-lnc` skill builds and configures an MCP server that
+connects to a Lightning node via Lightning Node Connect (encrypted WebSocket
+tunnels, pairing-phrase auth, no stored credentials). It exposes 18 read-only
+tools for querying node state and works with any MCP-compatible client.
 
 ## Quick Start
 
-### Install the plugin
+### Option A: Read-Only Node Access (MCP)
 
-Clone this repo and point Claude Code at it:
+The fastest path to interacting with a Lightning node. Requires a node running
+[Lightning Terminal](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/get-lit)
+and a pairing phrase.
 
 ```bash
 git clone https://github.com/lightninglabs/lightning-agent-kit.git
 cd lightning-agent-kit
-```
 
-Claude Code discovers skills via `.claude/skills/` automatically.
-
-### Example prompts
-
-```
-Get node info for sam in Docker regtest
-```
-
-```
-Bake a pay-only macaroon on zane in Docker regtest
-```
-
-```
-Export credentials from my signer and bake a signer-only macaroon
-```
-
-```
-Connect to my remote node at host:10009 and check the wallet balance
-```
-
-### Docker containers
-
-All scripts support `--container` for lnd nodes running in Docker:
-
-```bash
-skills/lnd/scripts/lncli.sh --container sam --network regtest getinfo
-skills/macaroon-bakery/scripts/bake.sh --role pay-only --container sam --network regtest
-```
-
-### Remote nodes
-
-All scripts support `--rpcserver`, `--tlscertpath`, and `--macaroonpath` for
-remote lnd nodes (e.g., Voltage):
-
-```bash
-skills/lnd/scripts/lncli.sh \
-    --rpcserver your-node.voltageapp.io:10009 \
-    --tlscertpath ~/tls.cert \
-    --macaroonpath ~/admin.macaroon \
-    --network mainnet getinfo
-```
-
-## Architecture
-
-```
-lightning-agent-kit/
-├── .claude/skills/          # Symlinks for Claude Code skill discovery
-├── .claude-plugin/          # Plugin metadata
-├── mcp-server/              # MCP server for Lightning Node Connect
-└── skills/
-    ├── lnd/                 # Lightning node operations
-    ├── lightning-security-module/  # Remote signer setup
-    ├── macaroon-bakery/     # Credential scoping
-    ├── mcp-lnc/             # MCP server build & config
-    ├── lnget/               # L402 HTTP client
-    ├── aperture/            # L402 reverse proxy
-    └── commerce/            # Full commerce workflow
-```
-
-## Security Model
-
-The default setup uses lnd's **remote signer architecture**:
-
-- **Signer machine** holds private keys, never routes payments
-- **Agent machine** runs a watch-only lnd node, delegates signing
-- Even if the agent machine is compromised, keys cannot be extracted
-
-For credentials, use the **macaroon-bakery** skill to bake least-privilege
-macaroons — never give agents `admin.macaroon` in production.
-
-## MCP Server
-
-The `mcp-server/` directory contains an MCP server that connects to lnd via
-Lightning Node Connect (LNC). This enables AI assistants to interact with
-Lightning nodes through the Model Context Protocol.
-
-Use the `mcp-lnc` skill to build, configure, and wire it into Claude Code:
-
-```bash
 skills/mcp-lnc/scripts/install.sh
-skills/mcp-lnc/scripts/configure.sh
-skills/mcp-lnc/scripts/setup-claude-config.sh
+skills/mcp-lnc/scripts/configure.sh --production
+skills/mcp-lnc/scripts/setup-claude-config.sh --scope project
 ```
+
+Restart Claude Code, then:
+
+```
+Connect to my Lightning node with pairing phrase: "word1 word2 ... word10"
+```
+
+The agent can now query balances, list channels, decode invoices, and inspect
+the network graph. See [MCP Server](docs/mcp-server.md) for details.
+
+### Option B: Full Commerce Stack
+
+Run your own node and start buying or selling resources over Lightning.
+
+```bash
+git clone https://github.com/lightninglabs/lightning-agent-kit.git
+cd lightning-agent-kit
+
+# Install components
+skills/lnd/scripts/install.sh
+skills/lnget/scripts/install.sh
+
+# Create and start a node
+skills/lnd/scripts/create-wallet.sh --mode standalone
+skills/lnd/scripts/start-lnd.sh
+
+# Configure lnget
+lnget config init
+
+# Fetch a paid resource
+lnget --max-cost 500 https://api.example.com/data.json
+```
+
+For the full walkthrough including wallet funding, channel management, and
+hosting your own paid endpoints, see [Commerce](docs/commerce.md).
+
+### Natural Language
+
+Agents with skill discovery (like Claude Code) pick up the skills automatically.
+You can interact through natural language:
+
+```
+Install Lightning Agent Tools and set up a Lightning node with
+remote signer so I can start paying for L402 APIs with lnget.
+```
+
+```
+Bake a pay-only macaroon on my regtest node
+```
+
+```
+Export credentials from my signer and set up a watch-only node
+```
+
+## Skills
+
+| Skill | What it does |
+|-------|-------------|
+| **lnd** | Installs and operates an lnd Lightning node. Neutrino light client, SQLite storage. Defaults to watch-only mode with remote signer. |
+| **lightning-security-module** | Sets up a remote signer node on a separate machine. Holds all private keys; the agent machine has none. |
+| **macaroon-bakery** | Bakes scoped macaroons (pay-only, invoice-only, read-only, channel-admin, signer-only) for least-privilege access. |
+| **lnget** | Command-line HTTP client with automatic L402 payment. Pays Lightning invoices on 402 responses, caches tokens, retries. |
+| **aperture** | L402 reverse proxy. Sits in front of a backend service, issues invoices, validates paid tokens, proxies authorized requests. |
+| **mcp-lnc** | Builds and configures the MCP server for LNC-based read-only access to a Lightning node. 18 tools, no stored credentials. |
+| **commerce** | Meta-skill orchestrating lnd + lnget + aperture for end-to-end buyer/seller workflows. |
+
+All scripts support `--container` for Docker-based lnd nodes and `--rpcserver`
+/ `--tlscertpath` / `--macaroonpath` for remote nodes.
+
+## Security
+
+The kit provides three tiers of access with increasing trust requirements:
+
+```mermaid
+graph LR
+    subgraph T1["Tier 1: Watch-Only + Remote Signer"]
+        A1["Agent: no keys"]
+        S1["Signer: holds keys"]
+        A1 ---|"gRPC"| S1
+    end
+
+    subgraph T2["Tier 2: Standalone"]
+        A2["Agent: keys on disk (0600)"]
+    end
+
+    subgraph T3["Tier 3: Read-Only via LNC"]
+        A3["Agent: no credentials on disk"]
+    end
+
+    T1 --- P1["Production"]
+    T2 --- P2["Testing"]
+    T3 --- P3["Observation"]
+```
+
+**Tier 1 (default)** splits the node into a watch-only instance on the agent
+machine and a signer on a separate machine. The agent can route payments and
+manage channels but cannot sign transactions. Keys never leave the signer.
+
+**Tier 2** stores keys locally. Appropriate for testnet, regtest, and small-value
+mainnet experiments.
+
+**Tier 3** uses the MCP server with LNC. No credentials are written to disk;
+the pairing phrase is handled in memory and ephemeral ECDSA keypairs are
+generated per session.
+
+For all tiers, use the `macaroon-bakery` to scope credentials. A buyer agent
+gets a `pay-only` macaroon; a monitoring agent gets `read-only`. Never hand out
+`admin.macaroon` in production.
+
+See [Security](docs/security.md) for threat models, hardening, and the
+production checklist.
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Architecture](docs/architecture.md) | System design, component map, plugin discovery, data flows |
+| [Security](docs/security.md) | Three-tier security model, remote signer, macaroon scoping, production checklist |
+| [L402 and lnget](docs/l402-and-lnget.md) | The L402 protocol, lnget usage, spending controls, token caching |
+| [MCP Server](docs/mcp-server.md) | LNC mechanics, setup walkthrough, 18-tool reference, configuration |
+| [Commerce](docs/commerce.md) | Buyer and seller agent setup, the commerce loop, cost management |
+| [Two-Agent Setup](docs/two-agent-setup.md) | Signer agent + node agent walkthrough for production key isolation |
+| [Quick Reference](docs/quickref.md) | Every command in one place |
+
+Each skill also has a detailed `SKILL.md` in its directory under `skills/` with
+operational reference material: script options, configuration templates, file
+paths, and troubleshooting.
 
 ## Prerequisites
 
-- **Go 1.21+** for building lnd/lncli from source
+- **Go 1.21+** for building lnd, lncli, lnget, and the MCP server from source
 - **Docker** (optional) for container-based lnd nodes
-- **jq** for JSON processing in scripts
+- **jq** for JSON processing in shell scripts
+- **Lightning Terminal** (optional) for generating LNC pairing phrases
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,363 @@
+# Architecture
+
+> How Lightning Agent Tools is structured and how its components interact.
+
+Lightning Agent Tools is composed of seven skills and an MCP server. Each skill
+manages a distinct piece of Lightning infrastructure (running a node, baking
+credentials, fetching paid content, hosting paid endpoints) and they compose
+together to give agents a full-stack payment capability. The skills are shell
+scripts and documentation that work with any agent framework capable of
+executing commands (Claude Code, Codex, or custom tooling). The MCP server
+follows the Model Context Protocol standard and works with any compatible
+client. This document explains how the pieces fit together.
+
+## Component Overview
+
+The kit has three layers: the Claude Code plugin interface, the skills that
+manage infrastructure, and the daemons and tools those skills operate.
+
+```mermaid
+graph TD
+    CC["Claude Code"] --> Skills
+
+    subgraph Skills["Skills Layer"]
+        lnd["lnd"]
+        lsm["lightning-security-module"]
+        mb["macaroon-bakery"]
+        lnget_skill["lnget"]
+        ap["aperture"]
+        mcp["mcp-lnc"]
+        com["commerce"]
+    end
+
+    subgraph Daemons["Runtime Layer"]
+        lnd_daemon["lnd daemon<br/>gRPC :10009 / P2P :9735"]
+        signer["lnd signer<br/>gRPC :10012"]
+        aperture_daemon["aperture proxy<br/>HTTP :8081"]
+        mcp_server["mcp-lnc-server<br/>stdio"]
+    end
+
+    subgraph External["External"]
+        ln["Lightning Network"]
+        mailbox["LNC Mailbox Relay"]
+        backend["Backend Service<br/>:8080"]
+    end
+
+    lnd --> lnd_daemon
+    lsm --> signer
+    mb --> lnd_daemon
+    lnget_skill --> lnget_cli["lnget CLI"]
+    ap --> aperture_daemon
+    mcp --> mcp_server
+
+    lnd_daemon <-->|"remote signing"| signer
+    lnd_daemon <--> ln
+    lnget_cli -->|"pays invoices via"| lnd_daemon
+    aperture_daemon -->|"generates invoices via"| lnd_daemon
+    aperture_daemon -->|"proxies to"| backend
+    mcp_server <-->|"encrypted WebSocket"| mailbox
+    mailbox <-->|"LNC tunnel"| lnd_daemon
+
+    com -.->|"orchestrates"| lnd
+    com -.->|"orchestrates"| lnget_skill
+    com -.->|"orchestrates"| ap
+```
+
+The `commerce` skill is a meta-skill. It doesn't manage any infrastructure
+directly but orchestrates `lnd`, `lnget`, and `aperture` together into buyer
+and seller workflows.
+
+## Plugin Discovery
+
+The kit ships as a Claude Code plugin but the underlying skills are
+framework-agnostic shell scripts. Any agent that can run bash commands can use
+them directly.
+
+For Claude Code, discovery happens through two mechanisms:
+
+**Plugin manifest.** The `.claude-plugin/plugin.json` file declares the plugin
+identity (name, version, author). Claude Code reads this when loading the
+project.
+
+**Skill symlinks.** The `.claude/skills/` directory contains symlinks pointing
+to each skill's directory under `skills/`:
+
+```
+.claude/skills/
+├── aperture → ../../skills/aperture
+├── commerce → ../../skills/commerce
+├── lightning-security-module → ../../skills/lightning-security-module
+├── lnd → ../../skills/lnd
+├── lnget → ../../skills/lnget
+├── macaroon-bakery → ../../skills/macaroon-bakery
+└── mcp-lnc → ../../skills/mcp-lnc
+```
+
+Each skill directory contains a `SKILL.md` file with YAML frontmatter declaring
+the skill's name, description, and whether it can be invoked directly by users.
+The skill's content (shell scripts, templates, reference docs) lives
+alongside it. In Claude Code, `SKILL.md` is injected into the agent's context
+when the skill is activated. In other frameworks, agents can read the `SKILL.md`
+directly and execute the shell scripts it references.
+
+## The Lightning Node
+
+The `lnd` skill manages an [lnd](https://github.com/lightningnetwork/lnd)
+daemon, the Lightning Network node that serves as the foundation for everything
+else in the kit. The node uses two lightweight backends to avoid requiring a
+full Bitcoin node:
+
+- **Neutrino** (BIP 157/158) for chain data. Fetches compact block filters
+  from a set of btcd peers rather than downloading the full blockchain.
+- **SQLite** for local storage. All channel state, invoices, and routing data
+  live in a single SQLite database rather than the default bbolt.
+
+The install script (`skills/lnd/scripts/install.sh`) builds lnd from source
+with the required build tags: `signrpc walletrpc chainrpc invoicesrpc routerrpc
+peersrpc kvdb_sqlite neutrinorpc`. The config template at
+`skills/lnd/templates/lnd.conf.template` gets deployed to
+`~/.lnget/lnd/lnd.conf`.
+
+### Watch-Only vs Standalone
+
+The node operates in one of two modes:
+
+**Watch-only (default).** The node has no private keys. It imports account xpubs
+from a remote signer and delegates all signing operations over gRPC. This is the
+production configuration. Even if the agent's machine is compromised, an
+attacker cannot sign transactions or extract keys because they don't exist on
+that machine.
+
+**Standalone.** The node generates and stores its own seed locally. The 24-word
+mnemonic is written to `~/.lnget/lnd/seed.txt` with mode 0600. This mode is
+appropriate for testnet, regtest, and development. It should not be used with
+significant funds.
+
+The mode is selected at wallet creation time via the `--mode` flag on
+`create-wallet.sh`. Once a wallet is created in one mode, the choice is
+permanent for that data directory.
+
+## Remote Signer
+
+The `lightning-security-module` skill sets up a second lnd instance that exists
+solely to hold private keys and sign transactions. This signer node never
+connects to the Lightning Network's peer-to-peer layer, never routes payments,
+and never opens channels. Its only network exposure is a gRPC interface on port
+10012 that the watch-only node connects to for signing requests.
+
+```mermaid
+sequenceDiagram
+    participant WO as Watch-Only Node<br/>(agent machine)
+    participant S as Signer Node<br/>(secure machine)
+    participant BTC as Bitcoin Network
+
+    WO->>WO: Constructs unsigned transaction
+    WO->>S: SignOutputRaw(tx, input_index)
+    S->>S: Validates signing request
+    S->>S: Signs with private key
+    S-->>WO: Returns signature
+    WO->>WO: Assembles signed transaction
+    WO->>BTC: Broadcasts transaction
+```
+
+The signer exports a **credentials bundle** containing three files:
+
+| File | Purpose |
+|------|---------|
+| `accounts.json` | Account xpubs for watch-only wallet import |
+| `tls.cert` | TLS certificate for authenticated gRPC |
+| `admin.macaroon` | RPC authentication token (scope down for production) |
+
+The bundle is generated by `setup-signer.sh` and written to
+`~/.lnget/signer/credentials-bundle/`. A base64-encoded tarball
+(`credentials-bundle.tar.gz.b64`) is also created for easy transfer to the
+agent machine. On the agent side, `import-credentials.sh` unpacks the bundle
+into `~/.lnget/lnd/signer-credentials/`.
+
+The signer's config (`skills/lightning-security-module/templates/signer-lnd.conf.template`)
+differs from a standard lnd config in important ways: it listens for RPC on
+`0.0.0.0:10012` to accept connections from the watch-only node, binds REST to
+`localhost:10013` only, includes `0.0.0.0` in the TLS certificate's extra IPs,
+and disables all routing and autopilot features.
+
+For a full discussion of threat models and hardening, see
+[Security](security.md).
+
+## Credentials
+
+lnd uses [macaroons](https://research.google/pubs/pub41892/) for RPC
+authentication. A macaroon is a bearer token: anyone who possesses it can
+exercise the permissions it encodes. The default `admin.macaroon` grants
+unrestricted access to every RPC method, which is why you should never hand it
+to an agent in production.
+
+The `macaroon-bakery` skill bakes scoped macaroons that grant only the
+permissions an agent needs. It ships with five preset roles:
+
+| Role | Can do | Cannot do |
+|------|--------|-----------|
+| `pay-only` | Pay and decode invoices | Create invoices, manage channels |
+| `invoice-only` | Create and look up invoices | Pay, manage channels |
+| `read-only` | Query balances, channels, peers, payments | Modify any state |
+| `channel-admin` | Everything in read-only + open/close channels | Pay or create invoices |
+| `signer-only` | Sign transactions, derive keys | Everything else |
+
+Custom macaroons can be baked with arbitrary permission sets by passing
+individual URI permissions to `bake.sh --custom`. The full list of available
+permissions is available via `bake.sh --list-permissions`.
+
+Macaroons are baked by the lnd node itself. The bakery script calls `lncli
+bakemacaroon` with the appropriate permission URIs. The resulting macaroon file
+should be stored with mode 0600 and treated like a password.
+
+```mermaid
+graph TD
+    admin["admin.macaroon<br/>(full access, never use in production)"]
+
+    admin -->|"bake --role pay-only"| payonly["pay-only.macaroon<br/>SendPayment, DecodePayReq, GetInfo"]
+    admin -->|"bake --role invoice-only"| invonly["invoice-only.macaroon<br/>AddInvoice, LookupInvoice, GetInfo"]
+    admin -->|"bake --role read-only"| readonly["read-only.macaroon<br/>GetInfo, balances, list operations"]
+    admin -->|"bake --role channel-admin"| chanadmin["channel-admin.macaroon<br/>read-only + OpenChannel, CloseChannel"]
+    admin -->|"bake --role signer-only"| signeronly["signer-only.macaroon<br/>SignOutputRaw, DeriveKey, MuSig2Sign"]
+```
+
+## MCP Server
+
+The MCP server (`mcp-server/`) connects AI assistants to a Lightning node
+through the [Model Context Protocol](https://modelcontextprotocol.io). It uses
+[Lightning Node Connect](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/lightning-node-connect)
+(LNC) to reach the node, which means the assistant never needs direct network
+access, TLS certificates, or macaroon files.
+
+LNC works by establishing an end-to-end encrypted WebSocket tunnel through a
+mailbox relay server. The agent and the lnd node each connect outbound to the
+mailbox. Neither needs to accept inbound connections. The tunnel is
+authenticated by a 10-word pairing phrase generated in Lightning Terminal.
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code
+    participant MCP as mcp-lnc-server
+    participant MB as Mailbox Relay
+    participant LND as lnd + Lightning Terminal
+
+    CC->>MCP: lnc_connect(pairing_phrase, password)
+    MCP->>MCP: Generate ephemeral ECDSA keypair
+    MCP->>MB: Open WebSocket (encrypted)
+    LND->>MB: Open WebSocket (encrypted)
+    MB-->>MCP: Tunnel established
+    MB-->>LND: Tunnel established
+
+    CC->>MCP: lnc_get_info()
+    MCP->>LND: GetInfo RPC (via tunnel)
+    LND-->>MCP: NodeInfo response
+    MCP-->>CC: Formatted node info
+
+    CC->>MCP: lnc_disconnect()
+    MCP->>MB: Close tunnel
+```
+
+The server runs on stdio transport. The MCP client (Claude Code or any other
+MCP-compatible host) launches it as a subprocess and communicates over
+stdin/stdout. No HTTP server, no port binding. The server's Go implementation
+lives under `mcp-server/` and is built via
+`skills/mcp-lnc/scripts/install.sh`.
+
+The server exposes 18 read-only tools organized into seven categories:
+Connection, Node, Channels, Invoices, Payments, Peers/Network, and On-Chain.
+None of these tools can modify node state. They query balances, list channels,
+decode invoices, and inspect the network graph, but they cannot send payments,
+open channels, or change configuration. See [MCP Server](mcp-server.md) for the
+full tool reference.
+
+Internally, the server uses a service manager
+(`mcp-server/internal/services/manager.go`) that initializes one service per
+tool category and registers their tools with the MCP SDK. When `lnc_connect`
+is called, the manager creates a Lightning client via LNC and distributes it to
+all services. When `lnc_disconnect` is called, the connection is closed and the
+ephemeral keypair is discarded.
+
+## L402 Commerce Flow
+
+The L402 protocol ties the system together for commerce. When an agent uses
+`lnget` to fetch a resource protected by `aperture`, the following exchange
+happens:
+
+```mermaid
+sequenceDiagram
+    participant Agent as Agent (lnget)
+    participant Aperture as Aperture (seller)
+    participant SellerLND as Seller's lnd
+    participant BuyerLND as Buyer's lnd
+    participant LN as Lightning Network
+
+    Agent->>Aperture: GET /api/data
+    Aperture->>SellerLND: Generate invoice (100 sats)
+    SellerLND-->>Aperture: BOLT11 invoice
+    Aperture-->>Agent: 402 Payment Required<br/>WWW-Authenticate: L402 macaroon=..., invoice=...
+
+    Agent->>Agent: Parse challenge, check amount ≤ max-cost
+    Agent->>BuyerLND: Pay invoice
+    BuyerLND->>LN: Route payment
+    LN->>SellerLND: Deliver payment
+    SellerLND-->>LN: Reveal preimage
+    LN-->>BuyerLND: Preimage
+    BuyerLND-->>Agent: Payment settled, preimage
+
+    Agent->>Agent: Cache token (macaroon + preimage)
+    Agent->>Aperture: GET /api/data<br/>Authorization: L402 <macaroon>:<preimage>
+    Aperture->>Aperture: Validate token
+    Aperture->>Aperture: Proxy to backend :8080
+    Aperture-->>Agent: 200 OK + response data
+```
+
+`lnget` handles this entire flow automatically. The agent runs a single command
+(`lnget https://api.example.com/data`) and receives the response data. The 402
+challenge, invoice payment, token caching, and authenticated retry happen
+transparently. Cached tokens are reused for subsequent requests to the same
+domain, avoiding repeat payments.
+
+On the server side, `aperture` sits in front of a backend HTTP service and
+intercepts requests to protected paths. It generates invoices through its
+connected lnd node, issues L402 challenges to unauthenticated requests, and
+validates paid tokens on retry. The backend service doesn't need to know
+anything about Lightning or L402.
+
+For the full protocol specification and client/server setup, see
+[L402 and lnget](l402-and-lnget.md) and [Commerce](commerce.md).
+
+## File System Layout
+
+All kit components store their data under predictable paths. The `~/.lnget/`
+tree is managed by the kit's scripts; `~/.lnd/` and `~/.aperture/` are
+managed by their respective daemons.
+
+| Path | Owner | Contents |
+|------|-------|----------|
+| `~/.lnget/lnd/lnd.conf` | lnd skill | Node configuration |
+| `~/.lnget/lnd/wallet-password.txt` | lnd skill | Wallet unlock passphrase (0600) |
+| `~/.lnget/lnd/seed.txt` | lnd skill | 24-word mnemonic, standalone only (0600) |
+| `~/.lnget/lnd/signer-credentials/` | lnd skill | Imported signer bundle (watch-only) |
+| `~/.lnget/signer/signer-lnd.conf` | security module | Signer node configuration |
+| `~/.lnget/signer/wallet-password.txt` | security module | Signer passphrase (0600) |
+| `~/.lnget/signer/seed.txt` | security module | Signer mnemonic (0600) |
+| `~/.lnget/signer/credentials-bundle/` | security module | Exported credentials for agent |
+| `~/.lnget/config.yaml` | lnget | lnget client configuration |
+| `~/.lnget/tokens/<domain>/` | lnget | Cached L402 tokens per domain |
+| `~/.lnd/` | lnd daemon | Chain data, macaroons, TLS cert/key, logs |
+| `~/.lnd-signer/` | signer daemon | Signer chain data, macaroons, TLS |
+| `~/.aperture/aperture.yaml` | aperture | Proxy configuration |
+| `~/.aperture/aperture.db` | aperture | SQLite token database |
+| `~/.aperture/tls.cert`, `tls.key` | aperture | TLS certificate and key |
+| `mcp-server/.env` | mcp-lnc | MCP server environment config |
+
+## Ports
+
+| Port | Service | Daemon | Interface |
+|------|---------|--------|-----------|
+| 9735 | Lightning P2P | lnd | 0.0.0.0 |
+| 10009 | gRPC | lnd | localhost |
+| 8080 | REST | lnd | localhost |
+| 10012 | gRPC | signer lnd | 0.0.0.0 |
+| 10013 | REST | signer lnd | localhost |
+| 8081 | HTTP (L402) | aperture | configurable |

--- a/docs/commerce.md
+++ b/docs/commerce.md
@@ -1,0 +1,348 @@
+# Agent Commerce
+
+> Setting up buyer and seller agents for autonomous Lightning payments.
+
+Lightning Agent Tools enables a payment pattern where agents buy and sell
+resources from each other over the Lightning Network without any pre-arranged
+billing relationship. A buyer agent uses `lnget` to fetch paid content. A
+seller agent uses `aperture` to gate access behind Lightning invoices. Both run
+their own `lnd` nodes for payment infrastructure. The three components compose
+into a self-contained commerce loop.
+
+This document walks through setting up both sides and running them together.
+
+## The Commerce Loop
+
+When a buyer agent fetches a resource from a seller, the following exchange
+happens automatically:
+
+```mermaid
+sequenceDiagram
+    participant BA as Buyer Agent
+    participant BL as Buyer lnd
+    participant LN as Lightning Network
+    participant SL as Seller lnd
+    participant AP as Aperture
+    participant BE as Backend Service
+
+    BA->>AP: GET /api/data (via lnget)
+    AP->>SL: Generate invoice (100 sats)
+    SL-->>AP: BOLT11 invoice
+    AP-->>BA: 402 + L402 challenge
+
+    BA->>BL: Pay invoice (100 sats)
+    BL->>LN: Route payment
+    LN->>SL: Deliver payment
+    SL-->>LN: Preimage
+    LN-->>BL: Preimage
+    BL-->>BA: Payment settled
+
+    BA->>AP: GET /api/data + L402 token
+    AP->>AP: Validate token
+    AP->>BE: Proxy request
+    BE-->>AP: Response data
+    AP-->>BA: 200 OK + data
+```
+
+From the buyer agent's perspective, this is a single command:
+
+```bash
+lnget --max-cost 100 -q https://seller-host:8081/api/data | jq .
+```
+
+From the seller's perspective, aperture handles everything: invoice
+generation, challenge issuance, token validation, and request proxying. The
+backend service just serves HTTP requests.
+
+## Buyer Agent Setup
+
+A buyer agent needs two components: an `lnd` node for payments and `lnget` for
+HTTP requests with automatic L402 handling.
+
+### Install
+
+```bash
+skills/lnd/scripts/install.sh
+skills/lnget/scripts/install.sh
+```
+
+### Create and Start the Node
+
+```bash
+# Create a wallet (standalone mode for testing, watch-only for production)
+skills/lnd/scripts/create-wallet.sh --mode standalone
+
+# Start lnd
+skills/lnd/scripts/start-lnd.sh
+
+# Verify it's running
+skills/lnd/scripts/lncli.sh getinfo
+```
+
+For production deployments, use watch-only mode with a remote signer. See
+[Security](security.md#tier-1-watch-only-with-remote-signer).
+
+### Fund the Wallet
+
+The node needs on-chain bitcoin to open payment channels.
+
+```bash
+# Generate a funding address
+skills/lnd/scripts/lncli.sh newaddress p2tr
+
+# Send BTC to this address from an exchange or another wallet
+
+# Check balance (wait for confirmations)
+skills/lnd/scripts/lncli.sh walletbalance
+```
+
+### Open a Channel
+
+Lightning payments travel through channels. The buyer needs at least one channel
+with outbound capacity to reach the seller (or a path to the seller through the
+network).
+
+```bash
+# Connect to a well-connected node
+skills/lnd/scripts/lncli.sh connect <pubkey>@<host>:9735
+
+# Open a channel (amount in satoshis)
+skills/lnd/scripts/lncli.sh openchannel --node_key=<pubkey> --local_amt=1000000
+
+# Wait for the funding transaction to confirm (typically 3-6 blocks)
+skills/lnd/scripts/lncli.sh pendingchannels
+skills/lnd/scripts/lncli.sh listchannels
+```
+
+### Configure lnget
+
+```bash
+# Initialize config (auto-detects local lnd)
+lnget config init
+
+# Verify backend connection
+lnget ln status
+```
+
+### Fetch Paid Resources
+
+```bash
+# Fetch with a spending cap
+lnget --max-cost 500 https://api.example.com/paid-data.json
+
+# Preview cost without paying
+lnget --no-pay --json https://api.example.com/paid-data.json | jq '.invoice_amount_sat'
+
+# Pipe to other tools
+lnget -q https://api.example.com/market-data.json | jq '.price'
+```
+
+## Seller Agent Setup
+
+A seller agent needs three components: an `lnd` node for invoice generation,
+`aperture` as the L402 reverse proxy, and a backend HTTP service to serve the
+actual content.
+
+### Install
+
+```bash
+skills/lnd/scripts/install.sh
+skills/aperture/scripts/install.sh
+```
+
+### Create and Start the Node
+
+```bash
+skills/lnd/scripts/create-wallet.sh --mode standalone
+skills/lnd/scripts/start-lnd.sh
+skills/lnd/scripts/lncli.sh getinfo
+```
+
+The seller's lnd node generates invoices for aperture. It needs inbound channel
+capacity to receive payments. Other nodes must have channels open _to_ the
+seller, not just from the seller.
+
+### Start a Backend Service
+
+Aperture proxies authenticated requests to a backend HTTP service. For testing,
+a simple file server works:
+
+```bash
+mkdir -p /tmp/api-data
+echo '{"market_data": {"btc_usd": 104250, "timestamp": "2025-02-09T12:00:00Z"}}' \
+    > /tmp/api-data/data.json
+cd /tmp/api-data && python3 -m http.server 8080 &
+```
+
+In production, the backend is whatever service you want to monetize: a REST
+API, a data feed, an inference endpoint.
+
+### Configure and Start Aperture
+
+```bash
+# Generate aperture config connected to local lnd
+skills/aperture/scripts/setup.sh --insecure --port 8081
+
+# Start the L402 proxy
+skills/aperture/scripts/start.sh
+```
+
+The `--insecure` flag disables TLS (suitable for development). For production,
+configure TLS with Let's Encrypt (`--autocert`) or your own certificates.
+
+Aperture's config (`~/.aperture/aperture.yaml`) defines which paths are
+protected and how much they cost:
+
+```yaml
+services:
+  - name: "market-data"
+    hostregexp: ".*"
+    pathregexp: "^/api/.*$"
+    address: "127.0.0.1:8080"
+    protocol: http
+    price: 100                    # satoshis per request
+    authwhitelistpaths:
+      - "^/health$"              # free health check endpoint
+```
+
+Each request to a path matching `^/api/.*$` costs 100 satoshis. Requests to
+`/health` pass through without payment. The `address` field points to the
+backend service.
+
+### Verify
+
+```bash
+# Should return 402 with L402 challenge
+lnget -k --no-pay https://localhost:8081/api/data.json
+```
+
+## Running Both Sides
+
+With both agents running, the buyer fetches data from the seller:
+
+```bash
+# Buyer fetches paid data
+lnget --max-cost 100 -q https://seller-host:8081/api/data.json | jq .
+```
+
+Verify the payment went through:
+
+```bash
+# On the buyer
+lnget tokens list                                    # shows cached token
+skills/lnd/scripts/lncli.sh channelbalance           # outbound decreased
+
+# On the seller
+skills/lnd/scripts/lncli.sh listinvoices             # shows settled invoice
+skills/lnd/scripts/lncli.sh channelbalance           # inbound converted to local
+```
+
+Subsequent requests from the buyer to the same domain reuse the cached token
+without additional payment (until the token expires).
+
+## Deployment Diagram
+
+A production deployment separates the signing infrastructure from the
+agent-facing components:
+
+```mermaid
+graph TB
+    subgraph Buyer["Buyer Agent"]
+        B_Agent["Agent Process"]
+        B_lnget["lnget"]
+        B_lnd["lnd (watch-only)"]
+        B_Signer["lnd signer<br/>(separate machine)"]
+
+        B_Agent --> B_lnget
+        B_lnget --> B_lnd
+        B_lnd <-->|"gRPC :10012"| B_Signer
+    end
+
+    subgraph Seller["Seller Agent"]
+        S_Agent["Agent Process"]
+        S_Aperture["aperture :8081"]
+        S_Backend["Backend :8080"]
+        S_lnd["lnd (watch-only)"]
+        S_Signer["lnd signer<br/>(separate machine)"]
+
+        S_Agent --> S_Aperture
+        S_Aperture --> S_Backend
+        S_Aperture --> S_lnd
+        S_lnd <-->|"gRPC :10012"| S_Signer
+    end
+
+    LN["Lightning Network"]
+    B_lnd <-->|":9735"| LN
+    S_lnd <-->|":9735"| LN
+```
+
+## Cost Management
+
+Agents operating autonomously need spending guardrails at multiple levels:
+
+**Per-request limits.** Set `--max-cost` on every lnget call. If the seller's
+price exceeds the limit, lnget refuses to pay and exits with code 2:
+
+```bash
+lnget --max-cost 500 https://api.example.com/data
+```
+
+**Cost preview.** Before committing to a purchase, preview what the server is
+charging:
+
+```bash
+lnget --no-pay --json https://api.example.com/data | jq '.invoice_amount_sat'
+```
+
+**Spending tracking.** Monitor cumulative spending through the token list:
+
+```bash
+lnget tokens list --json | jq '[.[] | .amount_paid_sat] | add'
+```
+
+**Wallet balance monitoring.** Check channel balance to ensure the agent has
+sufficient capacity:
+
+```bash
+skills/lnd/scripts/lncli.sh channelbalance
+skills/lnd/scripts/lncli.sh walletbalance
+```
+
+**Node-level controls.** Use a `pay-only` macaroon (via `macaroon-bakery`) for
+the buyer agent. This restricts lnget to payment and invoice-decoding operations
+only. The agent cannot open channels, change configuration, or access any
+other node functionality:
+
+```bash
+skills/macaroon-bakery/scripts/bake.sh --role pay-only
+```
+
+For the seller agent, use an `invoice-only` macaroon for aperture. It only needs
+to create and look up invoices.
+
+## Production Considerations
+
+**Remote signer.** Both buyer and seller nodes should run in watch-only mode
+with a remote signer in production. See
+[Security](security.md#tier-1-watch-only-with-remote-signer).
+
+**Inbound liquidity.** The seller's lnd node needs inbound channel capacity to
+receive payments. This means other nodes must open channels _to_ the seller.
+Options include requesting inbound channels from LSPs (Lightning Service
+Providers), or using circular rebalancing to shift local capacity to the remote
+side.
+
+**Channel sizing.** Size channels based on expected payment volume. A 1,000,000
+sat channel can handle many 100-sat L402 payments before rebalancing is needed.
+Monitor channel balances and open new channels proactively.
+
+**TLS for aperture.** Use `--autocert` with a domain name for automatic Let's
+Encrypt TLS, or provide your own certificate. Never run `--insecure` on
+public-facing endpoints.
+
+**Stopping everything.**
+
+```bash
+skills/aperture/scripts/stop.sh
+skills/lnd/scripts/stop-lnd.sh
+```

--- a/docs/l402-and-lnget.md
+++ b/docs/l402-and-lnget.md
@@ -1,0 +1,267 @@
+# L402 and lnget
+
+> The payment protocol that makes agent commerce work, and the CLI client that
+> automates it.
+
+L402 is an HTTP authentication scheme built on Lightning Network payments. It
+repurposes the HTTP 402 "Payment Required" status code, reserved since the
+early days of the HTTP spec but never widely adopted, to gate access to web
+resources behind Lightning invoices. An agent doesn't need an account, an API
+key, or a pre-existing relationship with the server. It pays a Lightning invoice
+and receives access. That's it.
+
+`lnget` is a command-line HTTP client (in the tradition of `wget` and `curl`)
+that handles L402 payments automatically. When it encounters a 402 response, it
+pays the embedded invoice, caches the resulting token, and retries the request.
+To the agent, the paid resource looks like any other HTTP fetch.
+
+## The L402 Protocol
+
+An L402 exchange has four steps:
+
+```mermaid
+sequenceDiagram
+    participant C as Client (lnget)
+    participant S as Server (aperture)
+    participant LN as Lightning Network
+
+    C->>S: GET /api/resource
+    S-->>C: 402 Payment Required<br/>WWW-Authenticate: L402<br/>macaroon="...", invoice="lnbc..."
+
+    Note over C: Parse macaroon and BOLT11 invoice<br/>Check: amount ≤ max-cost?
+
+    C->>LN: Pay BOLT11 invoice
+    LN-->>C: Preimage (proof of payment)
+
+    Note over C: Construct token: macaroon + preimage<br/>Cache token for this domain
+
+    C->>S: GET /api/resource<br/>Authorization: L402 <macaroon>:<preimage>
+    S-->>C: 200 OK + response body
+```
+
+**Step 1: The challenge.** The client requests a protected resource. The server
+responds with HTTP 402 and a `WWW-Authenticate` header containing two values: a
+macaroon (a bearer token encoding the access grant) and a BOLT11 Lightning
+invoice (the payment request).
+
+**Step 2: Payment.** The client decodes the BOLT11 invoice, verifies the amount
+is acceptable, and pays it through the Lightning Network. Payment settlement
+reveals a preimage, a 32-byte value that serves as cryptographic proof of
+payment.
+
+**Step 3: Token construction.** The client combines the macaroon from the
+challenge with the preimage from the payment to form an L402 token. This token
+is cached locally for future requests to the same domain.
+
+**Step 4: Authenticated retry.** The client retries the original request with an
+`Authorization: L402 <macaroon>:<preimage>` header. The server validates the
+token (verifying that the preimage matches the payment hash embedded in the
+macaroon) and serves the resource.
+
+The key property of L402 is that credentials are **purchased, not provisioned**.
+There is no signup flow, no API key management, no OAuth dance. Any client with
+access to the Lightning Network can authenticate with any L402 server
+instantly. This is what makes L402 native to agent workflows: agents can
+discover and pay for resources on the fly without requiring a human to pre-register
+accounts.
+
+## lnget
+
+`lnget` automates the entire L402 flow in a single command:
+
+```bash
+lnget https://api.example.com/premium-data.json
+```
+
+If the server returns 200, lnget writes the response to stdout (or a file with
+`-o`). If it returns 402, lnget parses the challenge, pays the invoice, caches
+the token, and retries. All of this is transparent. Subsequent requests to the same
+domain reuse the cached token without additional payment.
+
+### Installation
+
+```bash
+skills/lnget/scripts/install.sh
+```
+
+This runs `go install github.com/lightninglabs/lnget/cmd/lnget@latest`.
+
+### Lightning Backends
+
+lnget needs a Lightning backend to pay invoices. It supports three:
+
+```mermaid
+graph TD
+    lnget["lnget"]
+
+    lnget -->|"mode: lnd"| lnd["lnd (direct gRPC)<br/>Requires: host, TLS cert, macaroon<br/>Full payment capabilities"]
+    lnget -->|"mode: lnc"| lnc["LNC (Lightning Node Connect)<br/>Requires: pairing phrase<br/>Encrypted tunnel, no direct access"]
+    lnget -->|"mode: neutrino"| neutrino["Neutrino (embedded wallet)<br/>Self-contained light client<br/>No external node needed"]
+```
+
+**lnd (direct gRPC).** Connects to an lnd node over gRPC using a TLS
+certificate and macaroon. This is the standard mode when the agent runs its own
+lnd node via the `lnd` skill. Configure with:
+
+```bash
+lnget config init  # auto-detects local lnd
+```
+
+Or manually in `~/.lnget/config.yaml`:
+
+```yaml
+ln:
+  mode: lnd
+  lnd:
+    host: localhost:10009
+    tls_cert: ~/.lnd/tls.cert
+    macaroon: ~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
+    network: mainnet
+```
+
+Use a `pay-only` macaroon instead of `admin.macaroon` for agents. See
+[Security](security.md#preset-roles).
+
+**LNC (Lightning Node Connect).** Connects through an encrypted WebSocket
+tunnel using a pairing phrase. No direct network access to the lnd node is
+needed. Pair with:
+
+```bash
+lnget ln lnc pair "your ten word pairing phrase from lightning terminal"
+```
+
+**Neutrino (embedded wallet).** lnget runs its own lightweight Lightning wallet
+internally, using the Neutrino light client. No external lnd node required.
+Initialize with:
+
+```bash
+lnget ln neutrino init
+lnget ln neutrino fund  # generates a funding address
+```
+
+This mode is useful for quick experiments but has limited routing capability
+compared to a full lnd node.
+
+## Spending Controls
+
+Autonomous agents should never have unlimited spending authority. lnget provides
+two mechanisms for cost control:
+
+**Per-request ceiling.** The `--max-cost` flag sets the maximum amount (in
+satoshis) that lnget will auto-pay for a single request. If the invoice exceeds
+this amount, lnget exits with code 2 without paying:
+
+```bash
+lnget --max-cost 500 https://api.example.com/data
+```
+
+**Preview mode.** The `--no-pay` flag sends the request and displays the L402
+challenge (including the invoice amount) without paying. Agents can inspect
+costs before committing:
+
+```bash
+lnget --no-pay --json https://api.example.com/data | jq '.invoice_amount_sat'
+```
+
+For node-level spending limits, use the `macaroon-bakery` to bake a `pay-only`
+macaroon. This restricts the agent to payment operations only and prevents it
+from opening channels, modifying configuration, or performing other
+state-changing operations on the node.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Request succeeded |
+| 1 | General error |
+| 2 | Invoice amount exceeds `--max-cost` |
+| 3 | Lightning payment failed |
+| 4 | Network or connection error |
+
+## Token Caching
+
+Paid L402 tokens are cached at `~/.lnget/tokens/<domain>/` and reused
+automatically on subsequent requests to the same domain. This means an agent
+pays once per domain (until the token expires) rather than once per request.
+
+Manage cached tokens with:
+
+```bash
+lnget tokens list                        # list all cached tokens
+lnget tokens show api.example.com        # show token for a specific domain
+lnget tokens remove api.example.com      # remove a token (force re-payment)
+lnget tokens clear --force               # clear all tokens
+```
+
+## Configuration
+
+lnget reads its configuration from `~/.lnget/config.yaml`. Initialize it with:
+
+```bash
+lnget config init    # creates config with defaults, auto-detects local lnd
+lnget config show    # display current config
+lnget config path    # print config file path
+```
+
+The config file controls L402 behavior, HTTP settings, Lightning backend
+selection, and output formatting:
+
+```yaml
+l402:
+  max_cost_sats: 1000          # default spending ceiling
+  max_fee_sats: 10             # max routing fee
+  payment_timeout: 60s
+  auto_pay: true               # pay automatically on 402
+
+http:
+  timeout: 30s
+  max_redirects: 10
+  user_agent: "lnget/0.1.0"
+  allow_insecure: false        # set true for self-signed certs (dev only)
+
+ln:
+  mode: lnd                    # lnd | lnc | neutrino
+
+output:
+  format: json
+  progress: true
+  verbose: false
+
+tokens:
+  dir: ~/.lnget/tokens
+```
+
+## Common Usage Patterns
+
+```bash
+# Fetch and pipe to jq
+lnget -q https://api.example.com/data.json | jq .
+
+# Save to file
+lnget -o data.json https://api.example.com/data.json
+
+# POST with body
+lnget -X POST -d '{"query":"test"}' https://api.example.com/search
+
+# Check backend connection
+lnget ln status
+lnget ln info
+
+# Track total spending
+lnget tokens list --json | jq '[.[] | .amount_paid_sat] | add'
+```
+
+## The Server Side: Aperture
+
+lnget handles the client side of L402. On the server side,
+[Aperture](https://github.com/lightninglabs/aperture) is an L402-aware reverse
+proxy that sits in front of a backend HTTP service and gates access behind
+Lightning payments.
+
+Aperture handles invoice generation (through its connected lnd node), L402
+challenge issuance, token validation, and request proxying. The backend service
+doesn't need any awareness of Lightning or L402. It just serves HTTP requests
+that arrive through aperture.
+
+For a complete walkthrough of setting up both the client and server sides, see
+[Commerce](commerce.md).

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,285 @@
+# MCP Server
+
+> Connecting AI assistants to Lightning nodes through the Model Context
+> Protocol and Lightning Node Connect.
+
+Lightning Agent Tools includes an MCP server that gives AI assistants
+read-only access to a Lightning node. It uses Lightning Node Connect (LNC) for
+transport, which means the assistant never needs direct network access to the
+node, never handles TLS certificates, and never stores macaroons on disk. A
+10-word pairing phrase is all it takes to establish an encrypted tunnel.
+
+The server exposes 18 tools, all read-only, that let an assistant query
+node status, inspect channels, decode invoices, look up payments, and explore
+the network graph. It cannot send payments, open channels, or modify any node
+state.
+
+## How LNC Works
+
+Lightning Node Connect establishes an end-to-end encrypted WebSocket tunnel
+between two parties through a mailbox relay server. Both the MCP server (on the
+agent's machine) and the lnd node (running Lightning Terminal) connect outbound
+to the mailbox. Neither needs to accept inbound connections, which means no
+firewall configuration and no port forwarding.
+
+```mermaid
+graph LR
+    CC["Claude Code<br/>(stdio)"] <--> MCP["mcp-lnc-server"]
+    MCP <-->|"encrypted<br/>WebSocket"| MB["Mailbox Relay<br/>mailbox.terminal.lightning.today"]
+    MB <-->|"encrypted<br/>WebSocket"| LND["lnd + Lightning Terminal"]
+
+    style MB fill:#f5f5f5,stroke:#999
+```
+
+Authentication works through a 10-word pairing phrase generated in Lightning
+Terminal. When the MCP server connects, it generates an ephemeral ECDSA keypair,
+uses the pairing phrase to derive a shared secret, and establishes the encrypted
+tunnel. The keypair exists only in memory for the duration of the session --
+when the connection closes, the keypair is discarded and no credentials remain
+on disk.
+
+The mailbox relay cannot read the traffic passing through it. It sees encrypted
+WebSocket frames and routes them between the two endpoints based on connection
+identifiers derived from the pairing phrase.
+
+## Setup
+
+Three scripts handle the full setup:
+
+### 1. Build the server
+
+```bash
+skills/mcp-lnc/scripts/install.sh
+```
+
+This compiles `mcp-lnc-server` from the `mcp-server/` directory in the
+repository and installs it to `$GOPATH/bin`. Requires Go 1.24+.
+
+### 2. Configure the environment
+
+```bash
+# Production (Lightning Terminal on mainnet)
+skills/mcp-lnc/scripts/configure.sh --production
+
+# Development (local regtest)
+skills/mcp-lnc/scripts/configure.sh --dev --mailbox aperture:11110
+```
+
+This generates `mcp-server/.env` with the following variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LNC_MAILBOX_SERVER` | `mailbox.terminal.lightning.today:443` | Mailbox relay address |
+| `LNC_DEV_MODE` | `false` | Enable development mode |
+| `LNC_INSECURE` | `false` | Skip TLS verification (dev only) |
+| `LNC_CONNECT_TIMEOUT` | `30` | Connection timeout in seconds |
+
+### 3. Register with Claude Code
+
+```bash
+# Project-level (recommended)
+skills/mcp-lnc/scripts/setup-claude-config.sh --scope project
+
+# Global
+skills/mcp-lnc/scripts/setup-claude-config.sh --scope global
+```
+
+This adds the MCP server to `.mcp.json` (project) or `~/.claude.json` (global).
+Restart Claude Code after running this script for the new tools to appear.
+
+The resulting configuration looks like:
+
+```json
+{
+  "mcpServers": {
+    "lnc": {
+      "command": "mcp-lnc-server",
+      "env": {
+        "LNC_MAILBOX_SERVER": "mailbox.terminal.lightning.today:443"
+      }
+    }
+  }
+}
+```
+
+### 4. Connect
+
+After restarting Claude Code, the `lnc_connect` tool becomes available. Connect
+with a pairing phrase from Lightning Terminal:
+
+```
+Connect to my Lightning node with pairing phrase: "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10"
+```
+
+The assistant will call `lnc_connect`, establish the tunnel, and then all 18
+read-only tools become operational.
+
+## Available Tools
+
+The server organizes its 18 tools into seven categories:
+
+### Connection
+
+| Tool | Description |
+|------|-------------|
+| `lnc_connect` | Establish LNC tunnel with a pairing phrase and password |
+| `lnc_disconnect` | Close the active tunnel and discard the ephemeral keypair |
+
+### Node
+
+| Tool | Description |
+|------|-------------|
+| `lnc_get_info` | Node alias, public key, version, sync status, current block height |
+| `lnc_get_balance` | On-chain wallet balance and total channel balance |
+
+### Channels
+
+| Tool | Description |
+|------|-------------|
+| `lnc_list_channels` | All open channels with capacity, local/remote balances, and activity |
+| `lnc_pending_channels` | Channels being opened, closed, or force-closed |
+
+### Invoices
+
+| Tool | Description |
+|------|-------------|
+| `lnc_decode_invoice` | Decode a BOLT11 payment request into its components |
+| `lnc_list_invoices` | Paginated list of created invoices with status |
+| `lnc_lookup_invoice` | Look up a specific invoice by payment hash |
+
+### Payments
+
+| Tool | Description |
+|------|-------------|
+| `lnc_list_payments` | Paginated payment history with status, amounts, and routes |
+| `lnc_track_payment` | Track a specific in-flight or completed payment by hash |
+
+### Peers and Network
+
+| Tool | Description |
+|------|-------------|
+| `lnc_list_peers` | Connected peers with addresses, bytes sent/received, and ping times |
+| `lnc_describe_graph` | Sample of the Lightning Network topology (nodes and channels) |
+| `lnc_get_node_info` | Detailed information about a specific node by public key |
+
+### On-Chain
+
+| Tool | Description |
+|------|-------------|
+| `lnc_list_unspent` | Unspent transaction outputs (UTXOs) with confirmation counts |
+| `lnc_get_transactions` | On-chain transaction history |
+| `lnc_estimate_fee` | Fee rate estimates for target confirmation windows |
+
+## MCP-LNC vs Direct gRPC
+
+The MCP server and direct gRPC access (via `lncli` or the `lnd` skill) serve
+different purposes:
+
+| | MCP-LNC | Direct gRPC |
+|---|---------|-------------|
+| **Credentials** | Pairing phrase (in-memory) | TLS cert + macaroon (on disk) |
+| **Network** | WebSocket via mailbox relay | Direct TCP to gRPC port |
+| **Firewall** | No inbound ports needed | Port 10009 must be reachable |
+| **Capabilities** | Read-only (18 query tools) | Full node control |
+| **Permissions** | Hardcoded read-only | Configurable via macaroon scope |
+| **Setup** | Pairing phrase from Lightning Terminal | Export TLS cert and macaroon files |
+
+**Use MCP-LNC when** the agent only needs to observe node state: checking
+balances, listing channels, monitoring payments, inspecting the network graph.
+The read-only constraint and lack of stored credentials make it the safest
+option for giving an AI assistant access to node data.
+
+**Use direct gRPC when** the agent needs to perform actions: sending payments,
+opening channels, creating invoices. Direct gRPC requires the `lnd` skill and
+appropriate macaroons (scoped via `macaroon-bakery`).
+
+## Server Internals
+
+The MCP server is a Go application in the `mcp-server/` directory. It runs on
+stdio transport. The MCP client launches it as a subprocess and communicates over
+stdin/stdout.
+
+The entry point (`daemon.go`) handles signal-based shutdown (SIGINT, SIGTERM)
+with a graceful timeout. The server (`server.go`) initializes a service manager
+(`internal/services/manager.go`) that creates one service per tool category and
+registers all 18 tools with the
+[MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk).
+
+When `lnc_connect` is called, the manager creates a Lightning client using the
+LNC library (`github.com/lightninglabs/lightning-node-connect/mailbox`),
+establishes the tunnel, and distributes the client to all services via the
+`onLNCConnectionEstablished` callback. When `lnc_disconnect` is called, the
+connection is closed and all services are reset.
+
+### Building from Source
+
+```bash
+cd mcp-server
+make build           # debug binary
+make build-release   # optimized binary
+make install         # install to $GOPATH/bin
+make check           # run fmt, lint, mod-check, and unit tests
+```
+
+### Docker
+
+For containerized deployment:
+
+```bash
+cd mcp-server
+make docker-build
+```
+
+The Docker configuration in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "lnc": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i", "--network", "host",
+        "--env", "LNC_MAILBOX_SERVER",
+        "--env", "LNC_DEV_MODE",
+        "--env", "LNC_INSECURE",
+        "mcp-lnc-server"
+      ]
+    }
+  }
+}
+```
+
+## Development Setup
+
+For local regtest environments, enable development mode to skip TLS verification
+and connect to a local mailbox:
+
+```bash
+skills/mcp-lnc/scripts/configure.sh --dev --mailbox localhost:11110 --insecure
+```
+
+This sets `LNC_DEV_MODE=true` and `LNC_INSECURE=true` in the `.env` file.
+
+### Prerequisites
+
+- **Go 1.24+** for building from source
+- **Lightning Terminal** (litd) on the target lnd node for generating pairing
+  phrases
+- **Claude Code** for MCP integration
+
+### Troubleshooting
+
+**"pairing phrase must be exactly 10 words"**: The pairing phrase is generated
+in Lightning Terminal's Sessions UI. It must be exactly 10 space-separated
+words.
+
+**"connection timeout"**: Verify the mailbox server is reachable. For
+production, this is `mailbox.terminal.lightning.today:443`. For local
+development, ensure the local mailbox is running.
+
+**"TLS handshake failure"**: For local regtest, enable insecure mode:
+`skills/mcp-lnc/scripts/configure.sh --dev --insecure`
+
+**Tools not appearing in Claude Code**: Restart Claude Code after running
+`setup-claude-config.sh`. Verify the binary is on your PATH with
+`which mcp-lnc-server`.

--- a/docs/quickref.md
+++ b/docs/quickref.md
@@ -1,0 +1,231 @@
+# Quick Reference
+
+> Every important command in one place.
+
+## Installation
+
+```bash
+skills/lnd/scripts/install.sh                              # lnd + lncli
+skills/lnget/scripts/install.sh                            # lnget CLI
+skills/aperture/scripts/install.sh                         # aperture proxy
+skills/mcp-lnc/scripts/install.sh                          # MCP server
+skills/lightning-security-module/scripts/install.sh         # lnd (signer machine)
+```
+
+## Node Operations
+
+```bash
+skills/lnd/scripts/start-lnd.sh                            # start lnd
+skills/lnd/scripts/stop-lnd.sh                             # stop lnd
+skills/lnd/scripts/lncli.sh getinfo                        # node status
+skills/lnd/scripts/lncli.sh walletbalance                  # on-chain balance
+skills/lnd/scripts/lncli.sh channelbalance                 # channel balance
+skills/lnd/scripts/unlock-wallet.sh                        # unlock after restart
+```
+
+## Wallet
+
+```bash
+# Watch-only (production, imports xpubs from signer)
+skills/lnd/scripts/import-credentials.sh --bundle <path>
+skills/lnd/scripts/create-wallet.sh --signer-host <ip>:10012
+
+# Standalone (testing, generates local seed)
+skills/lnd/scripts/create-wallet.sh --mode standalone
+
+# Funding
+skills/lnd/scripts/lncli.sh newaddress p2tr               # generate address
+skills/lnd/scripts/lncli.sh walletbalance                  # check balance
+```
+
+## Channels
+
+```bash
+skills/lnd/scripts/lncli.sh connect <pubkey>@<host>:9735                      # connect to peer
+skills/lnd/scripts/lncli.sh openchannel --node_key=<pubkey> --local_amt=N      # open channel
+skills/lnd/scripts/lncli.sh listchannels                                       # list channels
+skills/lnd/scripts/lncli.sh pendingchannels                                    # pending opens/closes
+skills/lnd/scripts/lncli.sh closechannel --funding_txid=<txid> --output_index=N  # close channel
+skills/lnd/scripts/lncli.sh listpeers                                          # connected peers
+skills/lnd/scripts/lncli.sh disconnect <pubkey>                                # disconnect peer
+```
+
+## Payments
+
+```bash
+skills/lnd/scripts/lncli.sh addinvoice --amt=1000 --memo="description"    # create invoice
+skills/lnd/scripts/lncli.sh decodepayreq <bolt11>                          # decode invoice
+skills/lnd/scripts/lncli.sh sendpayment --pay_req=<bolt11>                 # pay invoice
+skills/lnd/scripts/lncli.sh listpayments                                   # payment history
+skills/lnd/scripts/lncli.sh listinvoices                                   # invoice history
+```
+
+## Macaroon Bakery
+
+```bash
+# Preset roles
+skills/macaroon-bakery/scripts/bake.sh --role pay-only
+skills/macaroon-bakery/scripts/bake.sh --role invoice-only
+skills/macaroon-bakery/scripts/bake.sh --role read-only
+skills/macaroon-bakery/scripts/bake.sh --role channel-admin
+skills/macaroon-bakery/scripts/bake.sh --role signer-only
+
+# Custom
+skills/macaroon-bakery/scripts/bake.sh --custom \
+    uri:/lnrpc.Lightning/SendPaymentSync \
+    uri:/lnrpc.Lightning/DecodePayReq \
+    uri:/lnrpc.Lightning/GetInfo
+
+# Inspect
+skills/macaroon-bakery/scripts/bake.sh --inspect <path-to-macaroon>
+
+# List all available permissions
+skills/macaroon-bakery/scripts/bake.sh --list-permissions
+
+# Save to specific path
+skills/macaroon-bakery/scripts/bake.sh --role pay-only --save-to ~/agent.macaroon
+```
+
+## lnget
+
+```bash
+# Fetch
+lnget https://api.example.com/data.json                   # fetch to stdout
+lnget -o data.json https://api.example.com/data.json       # fetch to file
+lnget -q https://api.example.com/data.json | jq .          # quiet mode, pipe
+lnget -X POST -d '{"q":"test"}' https://api.example.com    # POST with body
+
+# Cost control
+lnget --max-cost 500 https://api.example.com/data          # max auto-pay amount
+lnget --no-pay https://api.example.com/data                # preview without paying
+lnget --no-pay --json https://... | jq '.invoice_amount_sat'  # check price
+
+# Tokens
+lnget tokens list                                          # list cached tokens
+lnget tokens show api.example.com                          # show specific token
+lnget tokens remove api.example.com                        # force re-payment
+lnget tokens clear --force                                 # clear all tokens
+
+# Configuration
+lnget config init                                          # initialize config
+lnget config show                                          # show current config
+
+# Backend status
+lnget ln status                                            # connection status
+lnget ln info                                              # backend info
+
+# LNC pairing
+lnget ln lnc pair "ten word pairing phrase here"           # pair with LNC
+lnget ln lnc sessions                                      # list LNC sessions
+lnget ln lnc revoke <session-id>                           # revoke session
+
+# Neutrino (embedded wallet)
+lnget ln neutrino init                                     # initialize
+lnget ln neutrino fund                                     # funding address
+lnget ln neutrino balance                                  # check balance
+```
+
+## Aperture
+
+```bash
+skills/aperture/scripts/setup.sh                           # generate config
+skills/aperture/scripts/setup.sh --insecure --port 8081    # dev mode
+skills/aperture/scripts/setup.sh --network testnet         # testnet
+skills/aperture/scripts/start.sh                           # start proxy
+skills/aperture/scripts/stop.sh                            # stop proxy
+```
+
+## MCP Server
+
+```bash
+skills/mcp-lnc/scripts/install.sh                         # build from source
+skills/mcp-lnc/scripts/configure.sh                        # generate .env
+skills/mcp-lnc/scripts/configure.sh --production           # mainnet config
+skills/mcp-lnc/scripts/configure.sh --dev --insecure       # regtest config
+skills/mcp-lnc/scripts/setup-claude-config.sh --scope project   # add to .mcp.json
+skills/mcp-lnc/scripts/setup-claude-config.sh --scope global    # add to ~/.claude.json
+```
+
+## Remote Signer
+
+```bash
+# On signer machine
+skills/lightning-security-module/scripts/install.sh        # install lnd
+skills/lightning-security-module/scripts/setup-signer.sh   # create wallet + export creds
+skills/lightning-security-module/scripts/start-signer.sh   # start signer
+skills/lightning-security-module/scripts/stop-signer.sh    # stop signer
+skills/lightning-security-module/scripts/export-credentials.sh  # re-export bundle
+
+# On agent machine
+skills/lnd/scripts/import-credentials.sh --bundle <path>
+skills/lnd/scripts/create-wallet.sh --signer-host <ip>:10012
+skills/lnd/scripts/start-lnd.sh --signer-host <ip>:10012
+
+# Scope signer macaroon
+skills/macaroon-bakery/scripts/bake.sh --role signer-only \
+    --rpc-port 10012 --lnddir ~/.lnd-signer
+```
+
+## Docker Containers
+
+All `lncli` and bakery commands support `--container` for Docker-based nodes:
+
+```bash
+skills/lnd/scripts/lncli.sh --container sam --network regtest getinfo
+skills/lnd/scripts/lncli.sh --container sam --network regtest walletbalance
+skills/macaroon-bakery/scripts/bake.sh --role pay-only --container sam --network regtest
+skills/macaroon-bakery/scripts/bake.sh --inspect /root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --container sam
+skills/lnd/scripts/stop-lnd.sh --container sam
+skills/lightning-security-module/scripts/export-credentials.sh --container sam --network regtest
+```
+
+## Remote Nodes
+
+All scripts support direct connection to remote lnd nodes:
+
+```bash
+skills/lnd/scripts/lncli.sh \
+    --rpcserver remote-host:10009 \
+    --tlscertpath ~/remote-tls.cert \
+    --macaroonpath ~/remote-admin.macaroon \
+    getinfo
+
+skills/macaroon-bakery/scripts/bake.sh --role pay-only \
+    --rpcserver remote-host:10009 \
+    --tlscertpath ~/remote-tls.cert \
+    --macaroonpath ~/remote-admin.macaroon \
+    --save-to ~/remote-pay-only.macaroon
+```
+
+## File Paths
+
+| Path | Purpose |
+|------|---------|
+| `~/.lnget/lnd/lnd.conf` | lnd configuration |
+| `~/.lnget/lnd/wallet-password.txt` | Wallet passphrase (0600) |
+| `~/.lnget/lnd/seed.txt` | Wallet seed, standalone only (0600) |
+| `~/.lnget/lnd/signer-credentials/` | Imported signer credentials |
+| `~/.lnget/signer/signer-lnd.conf` | Signer configuration |
+| `~/.lnget/signer/wallet-password.txt` | Signer passphrase (0600) |
+| `~/.lnget/signer/seed.txt` | Signer seed (0600) |
+| `~/.lnget/signer/credentials-bundle/` | Exported signer credentials |
+| `~/.lnget/config.yaml` | lnget configuration |
+| `~/.lnget/tokens/<domain>/` | L402 cached tokens |
+| `~/.lnd/` | lnd data (chain, macaroons, TLS) |
+| `~/.lnd/data/chain/bitcoin/<network>/admin.macaroon` | Admin macaroon |
+| `~/.lnd/tls.cert` | lnd TLS certificate |
+| `~/.lnd-signer/` | Signer lnd data |
+| `~/.aperture/aperture.yaml` | Aperture configuration |
+| `~/.aperture/aperture.db` | Aperture token database |
+| `mcp-server/.env` | MCP server config |
+
+## Ports
+
+| Port | Service | Daemon |
+|------|---------|--------|
+| 9735 | Lightning P2P | lnd |
+| 10009 | gRPC | lnd |
+| 8080 | REST | lnd |
+| 10012 | gRPC | signer lnd |
+| 10013 | REST | signer lnd |
+| 8081 | HTTP/L402 | aperture (configurable) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,283 @@
+# Security Model
+
+> How Lightning Agent Tools isolates private keys, scopes credentials, and
+> controls what agents can do.
+
+Agents that handle real bitcoin need a security model built for autonomous
+operation. The core principle is straightforward: give the agent the minimum
+credentials required for its task and keep private keys on a separate machine.
+The kit enforces this through three tiers of access, each with different trust
+assumptions and failure modes.
+
+## Three Tiers of Access
+
+```mermaid
+graph LR
+    subgraph Tier1["Tier 1: Watch-Only + Remote Signer"]
+        direction TB
+        A1["Agent machine"]
+        S1["Signer machine"]
+        A1 --- |"gRPC/TLS"| S1
+        A1 -.- N1["No private keys"]
+        S1 -.- K1["Holds all keys"]
+    end
+
+    subgraph Tier2["Tier 2: Standalone"]
+        direction TB
+        A2["Agent machine"]
+        A2 -.- K2["Keys on disk<br/>(0600 permissions)"]
+    end
+
+    subgraph Tier3["Tier 3: Read-Only via MCP-LNC"]
+        direction TB
+        A3["Agent machine"]
+        MB["Mailbox relay"]
+        A3 --- |"encrypted WebSocket"| MB
+        A3 -.- N3["No credentials on disk<br/>Ephemeral keys only"]
+    end
+```
+
+### Tier 1: Watch-Only with Remote Signer
+
+This is the default and recommended configuration. The agent machine runs an
+lnd node in watch-only mode. It can see balances, manage channels, and route
+payments, but it has no private keys. All signing is delegated to a separate
+signer node over an authenticated gRPC connection.
+
+**What the agent machine has:**
+- Account xpubs (public keys for address derivation)
+- A TLS certificate and macaroon for the signer's gRPC interface
+- Scoped macaroons for the local lnd (baked via `macaroon-bakery`)
+
+**What the agent machine does not have:**
+- The wallet seed
+- Any private keys (funding, revocation, HTLC, or on-chain)
+
+**If the agent machine is compromised,** an attacker can observe channel state,
+balances, and payment history. They can see which peers the node is connected to
+and the topology of its channels. But they cannot sign transactions, sweep
+funds, or forge channel commitment updates. The keys are simply not there.
+
+**If the signer machine is compromised,** the attacker has full control over all
+private keys and can sign arbitrary transactions. This is a complete compromise.
+The signer machine should have a minimal attack surface: no public-facing
+services, restricted network access (only the watch-only node should reach port
+10012), and ideally dedicated hardware.
+
+**Setup:** Use the `lightning-security-module` skill on the signer machine and
+the `lnd` skill in watch-only mode on the agent machine. See
+[Architecture](architecture.md#remote-signer) for the signing flow.
+
+### Tier 2: Standalone
+
+The node generates its own seed and stores it locally. The 24-word mnemonic is
+written to `~/.lnget/lnd/seed.txt` and the wallet passphrase to
+`~/.lnget/lnd/wallet-password.txt`, both with mode 0600.
+
+This mode is appropriate for:
+- Testnet and regtest development
+- Small-value experiments on mainnet
+- Environments where a separate signer machine is impractical
+
+It is **not appropriate** for production deployments with significant funds.
+Anyone with read access to `~/.lnget/lnd/seed.txt` can reconstruct the wallet's
+private keys.
+
+**Setup:** Pass `--mode standalone` to `create-wallet.sh`.
+
+### Tier 3: Read-Only via MCP-LNC
+
+The MCP server connects to a Lightning node through an encrypted LNC tunnel
+using a 10-word pairing phrase. No credentials are written to disk. The
+pairing phrase is handled in memory and an ephemeral ECDSA keypair is generated
+per session. When the session ends, the keypair is discarded.
+
+This tier exposes 18 read-only tools. The agent can query balances, list
+channels, decode invoices, and inspect the network graph, but it cannot send
+payments, open channels, or modify any node state.
+
+**If the agent machine is compromised,** the attacker gains read access to the
+node's state for the duration of the active LNC session. Once the session is
+closed, no credentials remain to reconnect.
+
+**Setup:** Use the `mcp-lnc` skill. See [MCP Server](mcp-server.md) for the
+setup walkthrough.
+
+## Remote Signer in Depth
+
+The remote signer splits a Lightning node into two processes. The signer runs
+lnd with the seed and private keys but does not connect to the peer-to-peer
+network, does not route payments, and does not manage channels. The watch-only
+node does everything else.
+
+### Credential Bundle
+
+When you run `setup-signer.sh`, the signer creates a wallet and exports a
+credentials bundle to `~/.lnget/signer/credentials-bundle/`:
+
+| File | What it contains | What it's used for |
+|------|-----------------|-------------------|
+| `accounts.json` | Account xpubs (public keys) | Watch-only wallet creation |
+| `tls.cert` | Signer's TLS certificate | Authenticating the gRPC connection |
+| `admin.macaroon` | Signer's admin macaroon | Authorizing signing RPCs |
+
+A base64 tarball (`credentials-bundle.tar.gz.b64`) is also generated for
+transfer. On the agent machine, `import-credentials.sh` unpacks it into
+`~/.lnget/lnd/signer-credentials/`.
+
+### Signing Protocol
+
+The watch-only node constructs transactions locally and sends them to the signer
+for signature via gRPC. The signer validates each request, signs with the
+appropriate key, and returns the signature. The watch-only node then assembles
+and broadcasts the signed transaction.
+
+```mermaid
+sequenceDiagram
+    participant WO as Watch-Only lnd<br/>(agent machine)
+    participant S as Signer lnd<br/>(secure machine)
+    participant Net as Bitcoin Network
+
+    Note over WO: Needs to close a channel
+    WO->>WO: Build unsigned commitment tx
+    WO->>S: SignOutputRaw(unsigned_tx, key_desc)
+    S->>S: Look up private key
+    S->>S: Validate request
+    S->>S: Produce signature
+    S-->>WO: Signature bytes
+    WO->>WO: Attach signature to tx
+    WO->>Net: Broadcast signed tx
+```
+
+The gRPC connection between the watch-only node and the signer is secured with
+mutual TLS. The watch-only node uses the signer's exported TLS certificate
+(`tls.cert`) to verify the server's identity. The macaroon provides
+authorization.
+
+### Hardening the Signer
+
+For production deployments:
+
+- **Scope the signer macaroon.** Replace `admin.macaroon` with a `signer-only`
+  macaroon baked via `macaroon-bakery`. This restricts the watch-only node to
+  signing operations and key derivation. It cannot call any other RPC on the
+  signer.
+
+  ```bash
+  skills/macaroon-bakery/scripts/bake.sh --role signer-only \
+      --rpc-port 10012 --lnddir ~/.lnd-signer
+  ```
+
+- **Firewall the signer.** Only the watch-only node's IP should be able to
+  reach port 10012. Block all other inbound traffic.
+
+- **Dedicate the hardware.** Run the signer on a separate machine or hardened
+  VM with no other services. Minimize the installed software and disable remote
+  access except through a controlled management channel.
+
+- **Rotate macaroons.** Bake new macaroons periodically and update the
+  watch-only node's configuration. The old root key can be revoked to
+  invalidate the previous macaroon.
+
+## Macaroon Security
+
+Macaroons are bearer tokens. Anyone who has a copy of a macaroon can exercise
+its permissions against the lnd node that issued it. Treat them like passwords:
+store them with restrictive file permissions (0600), don't commit them to
+version control, and don't transmit them over unencrypted channels.
+
+### Preset Roles
+
+The `macaroon-bakery` skill provides five preset roles that cover common agent
+use cases. Each role grants the minimum set of RPC permissions needed:
+
+| Role | Permissions granted | Typical use case |
+|------|-------------------|-----------------|
+| `pay-only` | `SendPaymentSync`, `DecodePayReq`, `GetInfo` | Agent that buys L402 resources via lnget |
+| `invoice-only` | `AddInvoice`, `LookupInvoice`, `ListInvoices`, `GetInfo` | Agent that sells resources via aperture |
+| `read-only` | `GetInfo`, `WalletBalance`, `ChannelBalance`, `ListChannels`, `ListPeers`, `ListPayments`, `ListInvoices` | Monitoring and reporting |
+| `channel-admin` | Everything in `read-only` + `OpenChannelSync`, `CloseChannel`, `ConnectPeer` | Node management |
+| `signer-only` | `SignOutputRaw`, `ComputeInputScript`, `MuSig2Sign`, `DeriveKey`, `DeriveNextKey` | Remote signer credentials |
+
+### Custom Macaroons
+
+For permissions that don't fit a preset role, bake a custom macaroon with
+specific URI permissions:
+
+```bash
+skills/macaroon-bakery/scripts/bake.sh --custom \
+    uri:/lnrpc.Lightning/SendPaymentSync \
+    uri:/lnrpc.Lightning/DecodePayReq \
+    uri:/lnrpc.Lightning/WalletBalance \
+    uri:/lnrpc.Lightning/GetInfo
+```
+
+The full list of available permission URIs is available via:
+
+```bash
+skills/macaroon-bakery/scripts/bake.sh --list-permissions
+```
+
+### Rotation
+
+Macaroon rotation involves baking a new macaroon, updating the agent's
+configuration to use it, and optionally revoking the old root key:
+
+```bash
+# Bake replacement
+skills/macaroon-bakery/scripts/bake.sh --role pay-only \
+    --save-to ~/pay-only-v2.macaroon
+
+# Update agent config to point at the new macaroon
+
+# Revoke old root key (invalidates all macaroons baked with it)
+skills/lnd/scripts/lncli.sh bakemacaroon --root_key_id 0
+```
+
+## Production Checklist
+
+Before deploying the kit with real funds:
+
+1. **Use the remote signer.** Set up `lightning-security-module` on a separate
+   machine. Run the agent's lnd in watch-only mode. Do not use standalone mode
+   for production.
+
+2. **Scope all macaroons.** Bake role-specific macaroons for each agent. Never
+   distribute `admin.macaroon`. A buyer agent gets `pay-only`; a seller agent
+   gets `invoice-only`; a monitoring agent gets `read-only`.
+
+3. **Scope the signer macaroon.** Replace the signer's `admin.macaroon` with
+   a `signer-only` macaroon. The watch-only node only needs signing and key
+   derivation permissions on the signer.
+
+4. **Firewall the signer.** Restrict port 10012 to the watch-only node's IP.
+   Restrict port 10013 (REST) to localhost.
+
+5. **Secure credential files.** Verify that `wallet-password.txt`, `seed.txt`,
+   and all `.macaroon` files have mode 0600. The kit's scripts set this
+   automatically, but verify after any manual operations.
+
+6. **Set spending limits.** Configure `--max-cost` on lnget commands to cap
+   per-request spending. Monitor wallet balances programmatically.
+
+7. **Back up the seed.** The signer's `seed.txt` is the only way to recover
+   funds if the signer's storage fails. Store the 24-word mnemonic securely
+   offline.
+
+## Credential File Reference
+
+Every credential and secret file the kit manages:
+
+| File | Mode | Machine | Purpose |
+|------|------|---------|---------|
+| `~/.lnget/lnd/wallet-password.txt` | 0600 | Agent | lnd wallet unlock passphrase |
+| `~/.lnget/lnd/seed.txt` | 0600 | Agent | 24-word mnemonic (standalone only) |
+| `~/.lnget/lnd/signer-credentials/tls.cert` | 0644 | Agent | Signer's TLS cert |
+| `~/.lnget/lnd/signer-credentials/admin.macaroon` | 0600 | Agent | Signer RPC auth |
+| `~/.lnget/lnd/signer-credentials/accounts.json` | 0600 | Agent | Account xpubs |
+| `~/.lnget/signer/wallet-password.txt` | 0600 | Signer | Signer wallet passphrase |
+| `~/.lnget/signer/seed.txt` | 0600 | Signer | Signer 24-word mnemonic |
+| `~/.lnd/data/chain/bitcoin/<network>/admin.macaroon` | 0600 | Agent | lnd admin macaroon |
+| `~/.lnd-signer/data/chain/bitcoin/<network>/admin.macaroon` | 0600 | Signer | Signer admin macaroon |
+| `~/.lnget/tokens/<domain>/` | 0700 | Agent | Cached L402 tokens |
+| `~/.aperture/aperture.yaml` | 0600 | Seller | Aperture config (may contain credentials) |

--- a/docs/two-agent-setup.md
+++ b/docs/two-agent-setup.md
@@ -1,0 +1,307 @@
+# Two-Agent Secure Setup
+
+> Using one agent to set up the remote signer and another to run the
+> watch-only node.
+
+The recommended production deployment splits key management across two
+machines: a signer that holds private keys and a node that handles payments
+and channels. Each machine can be operated by its own agent. The signer agent
+runs on the secure machine and exports a credentials bundle. The node agent
+runs on the agent-facing machine, imports that bundle, and starts a watch-only
+lnd instance that delegates all signing back to the signer.
+
+This walkthrough covers the full flow from both sides.
+
+## Overview
+
+```mermaid
+sequenceDiagram
+    participant SA as Signer Agent<br/>(secure machine)
+    participant Transfer as Credentials Transfer
+    participant NA as Node Agent<br/>(agent machine)
+
+    SA->>SA: Install lnd
+    SA->>SA: Create signer wallet
+    SA->>SA: Start signer lnd
+    SA->>SA: Export credentials bundle
+    SA->>Transfer: credentials-bundle.tar.gz.b64
+
+    Transfer->>NA: Copy bundle to agent machine
+
+    NA->>NA: Install lnd
+    NA->>NA: Import credentials bundle
+    NA->>NA: Create watch-only wallet
+    NA->>NA: Start watch-only lnd
+    NA->>NA: Verify connection to signer
+```
+
+The credentials bundle contains three files:
+
+| File | What it is | What it's for |
+|------|-----------|---------------|
+| `accounts.json` | Account xpubs (public keys only) | Creating the watch-only wallet |
+| `tls.cert` | Signer's TLS certificate | Authenticating the gRPC connection |
+| `admin.macaroon` | Signer's RPC token | Authorizing signing requests |
+
+No private keys cross the wire. The bundle contains only public keys and
+authentication material.
+
+## Part 1: Signer Agent (Secure Machine)
+
+The signer agent runs on a machine with restricted access. This machine will
+hold all private keys and never connect to the Lightning Network directly.
+
+### Install lnd
+
+```bash
+skills/lightning-security-module/scripts/install.sh
+```
+
+This builds lnd with the signing-related build tags. The binary is the same as
+a regular lnd install, but the signer's configuration restricts it to signing
+operations only.
+
+### Create the signer wallet and export credentials
+
+```bash
+skills/lightning-security-module/scripts/setup-signer.sh
+```
+
+This does three things:
+
+1. Generates a new wallet with a random passphrase and 24-word seed mnemonic.
+   Both are saved to `~/.lnget/signer/` with mode 0600.
+2. Starts the signer lnd temporarily to extract account xpubs.
+3. Exports the credentials bundle to
+   `~/.lnget/signer/credentials-bundle/`.
+
+The bundle directory contains the three files listed above plus a
+base64-encoded tarball (`credentials-bundle.tar.gz.b64`) for easy transfer.
+
+### Start the signer
+
+```bash
+skills/lightning-security-module/scripts/start-signer.sh
+```
+
+The signer listens on port 10012 (gRPC) for signing requests from the
+watch-only node. It binds REST to localhost:10013 only. It does not connect to
+any peers and does not participate in the Lightning Network.
+
+### Transfer the bundle
+
+The base64-encoded bundle needs to reach the agent machine. How you transfer
+it depends on your environment:
+
+```bash
+# Option 1: scp
+scp ~/.lnget/signer/credentials-bundle/credentials-bundle.tar.gz.b64 \
+    agent-machine:~/credentials-bundle.tar.gz.b64
+
+# Option 2: Print to terminal and copy-paste
+cat ~/.lnget/signer/credentials-bundle/credentials-bundle.tar.gz.b64
+```
+
+The bundle contains a macaroon (bearer token) and a TLS certificate. Treat it
+like a password during transfer.
+
+### Optional: scope the signer macaroon
+
+The exported `admin.macaroon` grants full RPC access to the signer. For
+production, replace it with a `signer-only` macaroon that restricts the
+watch-only node to signing and key derivation:
+
+```bash
+skills/macaroon-bakery/scripts/bake.sh --role signer-only \
+    --rpc-port 10012 --lnddir ~/.lnd-signer
+```
+
+Then re-export the credentials bundle with the scoped macaroon:
+
+```bash
+skills/lightning-security-module/scripts/export-credentials.sh
+```
+
+## Part 2: Node Agent (Agent Machine)
+
+The node agent runs on the machine where agents will operate. This machine
+will have no private keys.
+
+### Install lnd
+
+```bash
+skills/lnd/scripts/install.sh
+```
+
+### Import the credentials bundle
+
+```bash
+skills/lnd/scripts/import-credentials.sh \
+    --bundle ~/credentials-bundle.tar.gz.b64
+```
+
+This unpacks the bundle into `~/.lnget/lnd/signer-credentials/`, placing
+`accounts.json`, `tls.cert`, and `admin.macaroon` where the watch-only node
+expects them.
+
+### Create the watch-only wallet
+
+```bash
+skills/lnd/scripts/create-wallet.sh \
+    --signer-host <signer-ip>:10012
+```
+
+Replace `<signer-ip>` with the signer machine's IP address or hostname. This
+creates a wallet that imports the account xpubs from the credentials bundle.
+The wallet has no seed and no private keys. It generates a random passphrase
+stored at `~/.lnget/lnd/wallet-password.txt` (mode 0600).
+
+The `--signer-host` flag tells the wallet creation process where to find the
+signer for initial key verification.
+
+### Start the watch-only node
+
+```bash
+skills/lnd/scripts/start-lnd.sh \
+    --signer-host <signer-ip>:10012
+```
+
+The node starts with `remotesigner.enable=true` in its config, pointing at
+the signer's gRPC address. It connects to the Bitcoin network via Neutrino,
+syncs headers, and begins normal operation. Any transaction that requires a
+signature (channel opens, closes, on-chain sends) is forwarded to the signer
+over the authenticated gRPC connection.
+
+### Verify
+
+```bash
+skills/lnd/scripts/lncli.sh getinfo
+```
+
+The node should report synced status. To confirm the signer connection is
+working, try generating a new address (which requires key derivation from the
+signer):
+
+```bash
+skills/lnd/scripts/lncli.sh newaddress p2tr
+```
+
+If this returns an address, the watch-only node and signer are communicating
+correctly.
+
+## What Each Agent Can See
+
+After setup, the two agents have different views of the system:
+
+```mermaid
+graph LR
+    subgraph Signer["Signer Agent"]
+        S_seed["Wallet seed (24 words)"]
+        S_keys["All private keys"]
+        S_pass["Wallet passphrase"]
+        S_mac["Signer macaroons"]
+    end
+
+    subgraph Node["Node Agent"]
+        N_xpubs["Account xpubs (public)"]
+        N_cert["Signer TLS cert"]
+        N_smac["Signer macaroon (scoped)"]
+        N_pass["Node wallet passphrase"]
+        N_mac["Node macaroons"]
+        N_state["Channel state, balances, peers"]
+    end
+
+    subgraph Neither["Neither Agent Has"]
+        X1["Cross-machine shell access"]
+        X2["Each other's wallet passphrase"]
+    end
+```
+
+The node agent can see balances, channel state, and payment history. It can
+initiate payments and open channels (the signing is handled transparently by
+the signer). It cannot extract private keys because they are not on its
+machine.
+
+The signer agent can see its own wallet state but has no visibility into the
+watch-only node's channels or payment activity. It responds to signing
+requests but does not initiate any network activity.
+
+## Network Requirements
+
+The watch-only node needs to reach the signer on port 10012 (gRPC over TLS).
+This is the only network path between the two machines.
+
+```mermaid
+graph LR
+    WO["Watch-Only Node"] -->|"TCP :10012<br/>gRPC/TLS"| S["Signer"]
+    WO -->|"TCP :9735<br/>Lightning P2P"| LN["Lightning Network"]
+    WO -->|"TCP :18333<br/>Neutrino"| BTC["Bitcoin Peers"]
+
+    S -.-x|"No outbound<br/>connections"| LN
+    S -.-x|"No outbound<br/>connections"| BTC
+```
+
+The signer should be firewalled to accept connections only from the watch-only
+node's IP on port 10012. It makes no outbound connections.
+
+## Ongoing Operations
+
+Once both sides are running, day-to-day operations happen on the node agent's
+machine:
+
+```bash
+# Check node status
+skills/lnd/scripts/lncli.sh getinfo
+
+# Fund the wallet
+skills/lnd/scripts/lncli.sh newaddress p2tr
+skills/lnd/scripts/lncli.sh walletbalance
+
+# Open channels
+skills/lnd/scripts/lncli.sh connect <pubkey>@<host>:9735
+skills/lnd/scripts/lncli.sh openchannel --node_key=<pubkey> --local_amt=1000000
+
+# Send payments
+skills/lnd/scripts/lncli.sh sendpayment --pay_req=<bolt11>
+
+# Use lnget for L402
+lnget --max-cost 500 https://api.example.com/data
+```
+
+The signer agent's role is maintenance: keeping the signer process running,
+rotating macaroons periodically, and backing up the seed.
+
+```bash
+# On the signer machine
+skills/lightning-security-module/scripts/start-signer.sh    # if stopped
+skills/lightning-security-module/scripts/stop-signer.sh     # for maintenance
+
+# Rotate the signer macaroon
+skills/macaroon-bakery/scripts/bake.sh --role signer-only \
+    --rpc-port 10012 --lnddir ~/.lnd-signer
+skills/lightning-security-module/scripts/export-credentials.sh
+
+# Then transfer the new bundle to the node agent and re-import
+```
+
+## Credential Scoping for the Node Agent
+
+After the watch-only node is running, bake scoped macaroons for the node
+agent's specific tasks. Do not leave the node agent using `admin.macaroon`:
+
+```bash
+# On the node agent's machine
+
+# For a buyer agent (pays for L402 resources)
+skills/macaroon-bakery/scripts/bake.sh --role pay-only
+
+# For a seller agent (generates invoices via aperture)
+skills/macaroon-bakery/scripts/bake.sh --role invoice-only
+
+# For a monitoring agent
+skills/macaroon-bakery/scripts/bake.sh --role read-only
+```
+
+This gives you two layers of credential scoping: the signer macaroon limits
+what the watch-only node can ask the signer to do, and the node macaroon
+limits what the agent can ask the watch-only node to do.


### PR DESCRIPTION
## Summary

- Rewrites README.md from 123 lines of boilerplate into ~235 lines of natural prose with mermaid diagrams, two quick-start paths, and a documentation table linking to all sub-docs
- Adds 6 new documents in `docs/` covering architecture, security, L402/lnget, MCP server, agent commerce, and a command quick reference
- Renames project to Lightning Agent Tools throughout
- Frames the toolkit as agent-framework-agnostic (Claude Code, Codex, or any agent that can run shell commands)
- Includes 14 mermaid diagrams across the doc set (component maps, sequence diagrams, security tier diagrams)
- All 21 referenced script paths verified to exist; all cross-links between docs verified valid

### New docs

| Document | Description |
|----------|-------------|
| `docs/architecture.md` | System design, component map, plugin discovery, remote signer flow, MCP internals, file layout |
| `docs/security.md` | Three-tier security model, remote signer deep dive, macaroon scoping, production checklist |
| `docs/l402-and-lnget.md` | L402 protocol walkthrough, lnget usage, spending controls, token caching, backend options |
| `docs/mcp-server.md` | LNC mechanics, setup walkthrough, 18-tool reference, configuration, dev setup |
| `docs/commerce.md` | Buyer/seller agent setup, commerce loop, cost management, production considerations |
| `docs/quickref.md` | Every command organized by task -- install, node ops, wallet, channels, payments, macaroons, lnget, aperture, MCP, signer, Docker, remote |

## Test plan

- [x] Verify mermaid diagrams render on GitHub PR preview
- [ ] Confirm all `docs/` links from README resolve correctly
- [ ] Confirm all script paths referenced in docs exist in repo
- [x] Read through for tone -- should read like established OSS project docs, not LLM output