### PR TITLE
docs: update documentation for container-first architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,19 @@ the network graph. See [MCP Server](docs/mcp-server.md) for details.
 
 ### Option B: Full Commerce Stack
 
-Run your own node and start buying or selling resources over Lightning.
+Run your own node and start buying or selling resources over Lightning. Docker
+is the default deployment method — `install.sh` pulls a container image and
+`start-lnd.sh` launches it via Docker Compose.
 
 ```bash
 git clone https://github.com/lightninglabs/lightning-agent-kit.git
 cd lightning-agent-kit
 
-# Install components
+# Install components (pulls Docker images by default; --source to build natively)
 skills/lnd/scripts/install.sh
 skills/lnget/scripts/install.sh
 
-# Create and start a node
+# Create and start a node (runs in a Docker container)
 skills/lnd/scripts/create-wallet.sh --mode standalone
 skills/lnd/scripts/start-lnd.sh
 
@@ -128,6 +130,10 @@ lnget config init
 # Fetch a paid resource
 lnget --max-cost 500 https://api.example.com/data.json
 ```
+
+All wrapper scripts (`start-lnd.sh`, `stop-lnd.sh`, `lncli.sh`) auto-detect
+Docker containers. Pass `--native` to any script to use a locally built binary
+instead.
 
 For the full walkthrough including wallet funding, channel management, and
 hosting your own paid endpoints, see [Commerce](docs/commerce.md).
@@ -226,10 +232,14 @@ paths, and troubleshooting.
 
 ## Prerequisites
 
-- **Go 1.21+** for building lnd, lncli, lnget, and the MCP server from source
-- **Docker** (optional) for container-based lnd nodes
+- **Docker** for running lnd/litd containers (the default deployment method)
+- **Go 1.21+** only needed when building from source (`install.sh --source`) or
+  for lnget and the MCP server
 - **jq** for JSON processing in shell scripts
 - **Lightning Terminal** (optional) for generating LNC pairing phrases
+
+Container image versions are pinned in `versions.env` at the repository root and
+can be overridden via environment variables.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,8 +30,8 @@ graph TD
         com["commerce"]
     end
 
-    subgraph Daemons["Runtime Layer"]
-        lnd_daemon["lnd daemon<br/>gRPC :10009 / P2P :9735"]
+    subgraph Daemons["Runtime Layer (Docker containers by default)"]
+        lnd_daemon["litd (Lightning Terminal)<br/>HTTPS :8443 / gRPC :10009 / P2P :9735"]
         signer["lnd signer<br/>gRPC :10012"]
         aperture_daemon["aperture proxy<br/>HTTP :8081"]
         mcp_server["mcp-lnc-server<br/>stdio"]
@@ -62,6 +62,12 @@ graph TD
     com -.->|"orchestrates"| lnget_skill
     com -.->|"orchestrates"| ap
 ```
+
+The runtime layer runs inside Docker containers by default. The primary
+container runs [litd](https://github.com/lightninglabs/lightning-terminal)
+(Lightning Terminal), which bundles lnd, Loop, Pool, Taproot Assets (tapd), and
+Faraday into a single process. The signer runs plain lnd in a separate
+container. All container images are pinned in `versions.env`.
 
 The `commerce` skill is a meta-skill. It doesn't manage any infrastructure
 directly but orchestrates `lnd`, `lnget`, and `aperture` together into buyer
@@ -102,21 +108,69 @@ directly and execute the shell scripts it references.
 
 ## The Lightning Node
 
-The `lnd` skill manages an [lnd](https://github.com/lightningnetwork/lnd)
-daemon, the Lightning Network node that serves as the foundation for everything
-else in the kit. The node uses two lightweight backends to avoid requiring a
-full Bitcoin node:
+The `lnd` skill manages a
+[litd](https://github.com/lightninglabs/lightning-terminal) (Lightning Terminal)
+instance, which bundles lnd with Loop, Pool, Taproot Assets, and Faraday in a
+single daemon. litd serves as the foundation for everything else in the kit. The
+node uses two lightweight backends to avoid requiring a full Bitcoin node:
 
 - **Neutrino** (BIP 157/158) for chain data. Fetches compact block filters
   from a set of btcd peers rather than downloading the full blockchain.
+  (Regtest mode uses a Bitcoin Core container instead.)
 - **SQLite** for local storage. All channel state, invoices, and routing data
   live in a single SQLite database rather than the default bbolt.
 
-The install script (`skills/lnd/scripts/install.sh`) builds lnd from source
+### Container-First Deployment
+
+The default deployment runs litd inside a Docker container. The install script
+(`skills/lnd/scripts/install.sh`) pulls the
+`lightninglabs/lightning-terminal` image from Docker Hub. Image versions are
+pinned in `versions.env` at the repo root and can be overridden at runtime via
+environment variables.
+
+For native builds, pass `--source` to `install.sh`, which builds lnd from source
 with the required build tags: `signrpc walletrpc chainrpc invoicesrpc routerrpc
-peersrpc kvdb_sqlite neutrinorpc`. The config template at
-`skills/lnd/templates/lnd.conf.template` gets deployed to
-`~/.lnget/lnd/lnd.conf`.
+peersrpc kvdb_sqlite neutrinorpc`.
+
+### Configuration
+
+The kit uses a config-file-driven approach. Config templates live in
+`skills/lnd/templates/` and are processed at container startup by
+`skills/lib/config-gen.sh`, which substitutes the network, debug level, node
+alias, UI password, and any extra arguments. The generated config is
+bind-mounted into the container as a read-only file. This avoids the fragility
+of long `docker run` command-line flag lists.
+
+Three Docker Compose files define the container topology for each mode:
+
+| File | Mode | Containers |
+|------|------|-----------|
+| `docker-compose.yml` | Standalone | litd (neutrino) |
+| `docker-compose-regtest.yml` | Regtest | litd + Bitcoin Core (+ optional litd-bob) |
+| `docker-compose-watchonly.yml` | Watch-only | litd + signer lnd |
+
+### Profiles
+
+Profile files in `skills/lnd/profiles/` let you customize behavior without
+editing templates. Each profile is a `.env` file that sets `LND_DEBUG`,
+`LITD_EXTRA_ARGS`, and optionally `LITD_ALIAS`. Available profiles:
+
+| Profile | Purpose |
+|---------|---------|
+| `default.env` | Standard operation (info-level logging) |
+| `debug.env` | Verbose per-subsystem tracing |
+| `regtest.env` | Local development on regtest |
+| `taproot.env` | Enables simple taproot channels |
+| `wumbo.env` | Large channels up to 10 BTC |
+
+Start with a profile: `skills/lnd/scripts/start-lnd.sh --profile debug`
+
+### Native Mode
+
+All wrapper scripts (`start-lnd.sh`, `stop-lnd.sh`, `lncli.sh`) accept a
+`--native` flag to bypass Docker and use a locally installed lnd binary. In
+native mode, the config template at `skills/lnd/templates/lnd.conf.template`
+is deployed to `~/.lnget/lnd/lnd.conf`.
 
 ### Watch-Only vs Standalone
 
@@ -144,6 +198,12 @@ solely to hold private keys and sign transactions. This signer node never
 connects to the Lightning Network's peer-to-peer layer, never routes payments,
 and never opens channels. Its only network exposure is a gRPC interface on port
 10012 that the watch-only node connects to for signing requests.
+
+By default, the signer runs in a Docker container named `litd-signer`, defined
+in `skills/lightning-security-module/templates/docker-compose-signer.yml`. The
+`setup-signer.sh` script auto-detects a running `litd-signer` container and
+routes wallet creation and credential export through it. Pass `--native` to
+use a locally installed lnd binary instead.
 
 ```mermaid
 sequenceDiagram
@@ -177,8 +237,10 @@ into `~/.lnget/lnd/signer-credentials/`.
 The signer's config (`skills/lightning-security-module/templates/signer-lnd.conf.template`)
 differs from a standard lnd config in important ways: it listens for RPC on
 `0.0.0.0:10012` to accept connections from the watch-only node, binds REST to
-`localhost:10013` only, includes `0.0.0.0` in the TLS certificate's extra IPs,
-and disables all routing and autopilot features.
+`0.0.0.0:10013` (container mode needs this for host connectivity; native mode
+rebinds to `localhost`), includes container hostnames (`signer`, `litd-signer`)
+in the TLS certificate's extra domains, and disables all routing and autopilot
+features.
 
 For a full discussion of threat models and hardening, see
 [Security](security.md).
@@ -332,9 +394,10 @@ All kit components store their data under predictable paths. The `~/.lnget/`
 tree is managed by the kit's scripts; `~/.lnd/` and `~/.aperture/` are
 managed by their respective daemons.
 
+### Host Files (managed by kit scripts)
+
 | Path | Owner | Contents |
 |------|-------|----------|
-| `~/.lnget/lnd/lnd.conf` | lnd skill | Node configuration |
 | `~/.lnget/lnd/wallet-password.txt` | lnd skill | Wallet unlock passphrase (0600) |
 | `~/.lnget/lnd/seed.txt` | lnd skill | 24-word mnemonic, standalone only (0600) |
 | `~/.lnget/lnd/signer-credentials/` | lnd skill | Imported signer bundle (watch-only) |
@@ -344,20 +407,49 @@ managed by their respective daemons.
 | `~/.lnget/signer/credentials-bundle/` | security module | Exported credentials for agent |
 | `~/.lnget/config.yaml` | lnget | lnget client configuration |
 | `~/.lnget/tokens/<domain>/` | lnget | Cached L402 tokens per domain |
-| `~/.lnd/` | lnd daemon | Chain data, macaroons, TLS cert/key, logs |
-| `~/.lnd-signer/` | signer daemon | Signer chain data, macaroons, TLS |
-| `~/.aperture/aperture.yaml` | aperture | Proxy configuration |
-| `~/.aperture/aperture.db` | aperture | SQLite token database |
-| `~/.aperture/tls.cert`, `tls.key` | aperture | TLS certificate and key |
 | `mcp-server/.env` | mcp-lnc | MCP server environment config |
+
+### Daemon Data (native mode: filesystem; container mode: Docker volumes)
+
+In container mode, the following paths live inside named Docker volumes rather
+than on the host filesystem. Use `docker volume ls` to list them and
+`docker volume inspect <name>` for mount details.
+
+| Path / Volume | Mode | Contents |
+|---------------|------|----------|
+| `~/.lnd/` / `litd-data` | native / container | lnd chain data, macaroons, TLS cert/key, logs |
+| `~/.lnd-signer/` / `signer-data` | native / container | Signer chain data, macaroons, TLS |
+| — / `litd-lit-data` | container only | litd-specific state (sessions, accounts) |
+| `~/.aperture/` / `aperture-data` | native / container | Aperture config, database, TLS |
+
+### Kit Infrastructure
+
+| Path | Purpose |
+|------|---------|
+| `versions.env` | Pinned container image versions (litd, lnd, aperture, Bitcoin Core) |
+| `skills/lib/config-gen.sh` | Shared config generation functions for templates |
+| `skills/lib/rest.sh` | Shared REST API call helpers (native + container) |
+| `skills/lnd/templates/` | Config templates and Docker Compose files |
+| `skills/lnd/profiles/` | Profile `.env` files (default, debug, regtest, taproot, wumbo) |
+| `skills/lightning-security-module/templates/` | Signer config template and Docker Compose |
+| `skills/aperture/templates/` | Aperture config template and Docker Compose |
 
 ## Ports
 
 | Port | Service | Daemon | Interface |
 |------|---------|--------|-----------|
+| 8443 | HTTPS (UI + gRPC + REST) | litd | 0.0.0.0 (container) |
 | 9735 | Lightning P2P | lnd | 0.0.0.0 |
 | 10009 | gRPC | lnd | localhost |
 | 8080 | REST | lnd | localhost |
 | 10012 | gRPC | signer lnd | 0.0.0.0 |
-| 10013 | REST | signer lnd | localhost |
+| 10013 | REST | signer lnd | 0.0.0.0 (container) / localhost (native) |
 | 8081 | HTTP (L402) | aperture | configurable |
+
+Regtest mode adds:
+
+| Port | Service | Daemon |
+|------|---------|--------|
+| 18443 | Bitcoin RPC | bitcoind |
+| 28332 | ZMQ block notifications | bitcoind |
+| 28333 | ZMQ tx notifications | bitcoind |

--- a/docs/commerce.md
+++ b/docs/commerce.md
@@ -62,17 +62,21 @@ HTTP requests with automatic L402 handling.
 ### Install
 
 ```bash
+# Pulls Docker images by default; add --source to build from source.
 skills/lnd/scripts/install.sh
 skills/lnget/scripts/install.sh
 ```
 
 ### Create and Start the Node
 
+All commands below auto-detect Docker and launch containers. Pass `--native` to
+any script to use a locally built binary instead.
+
 ```bash
 # Create a wallet (standalone mode for testing, watch-only for production)
 skills/lnd/scripts/create-wallet.sh --mode standalone
 
-# Start lnd
+# Start lnd (launches a litd Docker container)
 skills/lnd/scripts/start-lnd.sh
 
 # Verify it's running
@@ -154,7 +158,7 @@ skills/aperture/scripts/install.sh
 
 ```bash
 skills/lnd/scripts/create-wallet.sh --mode standalone
-skills/lnd/scripts/start-lnd.sh
+skills/lnd/scripts/start-lnd.sh                            # Docker container by default
 skills/lnd/scripts/lncli.sh getinfo
 ```
 
@@ -189,6 +193,10 @@ skills/aperture/scripts/start.sh
 
 The `--insecure` flag disables TLS (suitable for development). For production,
 configure TLS with Let's Encrypt (`--autocert`) or your own certificates.
+
+For regtest testing, a Docker Compose file at
+`skills/aperture/templates/docker-compose-aperture.yml` runs aperture alongside
+a busybox backend on the same Docker network as the litd regtest stack.
 
 Aperture's config (`~/.aperture/aperture.yaml`) defines which paths are
 protected and how much they cost:
@@ -345,4 +353,5 @@ public-facing endpoints.
 ```bash
 skills/aperture/scripts/stop.sh
 skills/lnd/scripts/stop-lnd.sh
+skills/lnd/scripts/stop-lnd.sh --clean                     # also remove Docker volumes
 ```

--- a/docs/quickref.md
+++ b/docs/quickref.md
@@ -5,18 +5,27 @@
 ## Installation
 
 ```bash
-skills/lnd/scripts/install.sh                              # lnd + lncli
-skills/lnget/scripts/install.sh                            # lnget CLI
-skills/aperture/scripts/install.sh                         # aperture proxy
-skills/mcp-lnc/scripts/install.sh                          # MCP server
-skills/lightning-security-module/scripts/install.sh         # lnd (signer machine)
+# Docker image pull is the default; add --source to build from source instead.
+skills/lnd/scripts/install.sh                              # litd container image
+skills/lnget/scripts/install.sh                            # lnget CLI (always built from source)
+skills/aperture/scripts/install.sh                         # aperture (always built from source)
+skills/mcp-lnc/scripts/install.sh                          # MCP server (always built from source)
+skills/lightning-security-module/scripts/install.sh         # lnd signer container image
 ```
 
 ## Node Operations
 
 ```bash
-skills/lnd/scripts/start-lnd.sh                            # start lnd
-skills/lnd/scripts/stop-lnd.sh                             # stop lnd
+# Start/stop (Docker container by default; --native for local binary)
+skills/lnd/scripts/start-lnd.sh                            # start litd container (standalone)
+skills/lnd/scripts/start-lnd.sh --watchonly                # watch-only + signer containers
+skills/lnd/scripts/start-lnd.sh --regtest                  # regtest + bitcoind containers
+skills/lnd/scripts/start-lnd.sh --profile debug            # start with debug logging profile
+skills/lnd/scripts/docker-start.sh --list-profiles         # list available profiles
+skills/lnd/scripts/stop-lnd.sh                             # stop containers
+skills/lnd/scripts/stop-lnd.sh --clean                     # stop + remove Docker volumes
+
+# Node queries (auto-detects containers)
 skills/lnd/scripts/lncli.sh getinfo                        # node status
 skills/lnd/scripts/lncli.sh walletbalance                  # on-chain balance
 skills/lnd/scripts/lncli.sh channelbalance                 # channel balance
@@ -26,9 +35,13 @@ skills/lnd/scripts/unlock-wallet.sh                        # unlock after restar
 ## Wallet
 
 ```bash
-# Watch-only (production, imports xpubs from signer)
+# Watch-only with Docker (signer on Docker network, no --signer-host needed)
 skills/lnd/scripts/import-credentials.sh --bundle <path>
-skills/lnd/scripts/create-wallet.sh --signer-host <ip>:10012
+skills/lnd/scripts/create-wallet.sh                        # auto-detects container
+
+# Watch-only with native (signer on separate machine)
+skills/lnd/scripts/import-credentials.sh --bundle <path>
+skills/lnd/scripts/create-wallet.sh --native --signer-host <ip>:10012
 
 # Standalone (testing, generates local seed)
 skills/lnd/scripts/create-wallet.sh --mode standalone
@@ -149,34 +162,52 @@ skills/mcp-lnc/scripts/setup-claude-config.sh --scope global    # add to ~/.clau
 ## Remote Signer
 
 ```bash
-# On signer machine
-skills/lightning-security-module/scripts/install.sh        # install lnd
-skills/lightning-security-module/scripts/setup-signer.sh   # create wallet + export creds
-skills/lightning-security-module/scripts/start-signer.sh   # start signer
-skills/lightning-security-module/scripts/stop-signer.sh    # stop signer
-skills/lightning-security-module/scripts/export-credentials.sh  # re-export bundle
+# On signer machine (Docker container by default)
+skills/lightning-security-module/scripts/install.sh        # pull lnd signer image
+skills/lightning-security-module/scripts/setup-signer.sh   # create wallet + export creds (auto-detects container)
+skills/lightning-security-module/scripts/start-signer.sh   # start signer container
+skills/lightning-security-module/scripts/stop-signer.sh    # stop signer container
+skills/lightning-security-module/scripts/stop-signer.sh --clean  # stop + remove volumes
+skills/lightning-security-module/scripts/export-credentials.sh   # re-export bundle
 
-# On agent machine
+# On agent machine (Docker)
 skills/lnd/scripts/import-credentials.sh --bundle <path>
-skills/lnd/scripts/create-wallet.sh --signer-host <ip>:10012
-skills/lnd/scripts/start-lnd.sh --signer-host <ip>:10012
+skills/lnd/scripts/create-wallet.sh                        # auto-detects container
+skills/lnd/scripts/start-lnd.sh --watchonly                # watch-only + signer containers
 
-# Scope signer macaroon
-skills/macaroon-bakery/scripts/bake.sh --role signer-only \
-    --rpc-port 10012 --lnddir ~/.lnd-signer
+# On agent machine (native, signer on separate host)
+skills/lnd/scripts/import-credentials.sh --bundle <path>
+skills/lnd/scripts/create-wallet.sh --native --signer-host <ip>:10012
+skills/lnd/scripts/start-lnd.sh --native --signer-host <ip>:10012
+
+# Scope signer macaroon (container or native)
+skills/macaroon-bakery/scripts/bake.sh --role signer-only --container litd-signer
+skills/macaroon-bakery/scripts/bake.sh --role signer-only --rpc-port 10012 --lnddir ~/.lnd-signer
 ```
 
 ## Docker Containers
 
-All `lncli` and bakery commands support `--container` for Docker-based nodes:
+Docker is the default deployment method. Container lifecycle:
 
 ```bash
-skills/lnd/scripts/lncli.sh --container sam --network regtest getinfo
-skills/lnd/scripts/lncli.sh --container sam --network regtest walletbalance
-skills/macaroon-bakery/scripts/bake.sh --role pay-only --container sam --network regtest
-skills/macaroon-bakery/scripts/bake.sh --inspect /root/.lnd/data/chain/bitcoin/regtest/admin.macaroon --container sam
-skills/lnd/scripts/stop-lnd.sh --container sam
-skills/lightning-security-module/scripts/export-credentials.sh --container sam --network regtest
+# Lifecycle (these are the primary entry points)
+skills/lnd/scripts/start-lnd.sh                            # standalone litd container
+skills/lnd/scripts/start-lnd.sh --watchonly                # litd + signer containers
+skills/lnd/scripts/start-lnd.sh --regtest                  # litd + bitcoind containers
+skills/lnd/scripts/start-lnd.sh --regtest --profile debug  # regtest with debug logging
+skills/lnd/scripts/stop-lnd.sh                             # stop all mode containers
+skills/lnd/scripts/stop-lnd.sh --clean                     # stop + remove volumes
+skills/lnd/scripts/docker-start.sh --list-profiles         # show available profiles
+```
+
+All `lncli` and bakery commands auto-detect running containers. Use `--container`
+to target a specific container by name:
+
+```bash
+skills/lnd/scripts/lncli.sh getinfo                        # auto-detects litd container
+skills/lnd/scripts/lncli.sh --container litd-bob getinfo   # target specific container
+skills/macaroon-bakery/scripts/bake.sh --role pay-only --container litd
+skills/lightning-security-module/scripts/export-credentials.sh --container litd-signer
 ```
 
 ## Remote Nodes
@@ -223,6 +254,7 @@ skills/macaroon-bakery/scripts/bake.sh --role pay-only \
 
 | Port | Service | Daemon |
 |------|---------|--------|
+| 8443 | HTTPS (UI + gRPC + REST) | litd (container) |
 | 9735 | Lightning P2P | lnd |
 | 10009 | gRPC | lnd |
 | 8080 | REST | lnd |

--- a/docs/security.md
+++ b/docs/security.md
@@ -108,7 +108,9 @@ setup walkthrough.
 The remote signer splits a Lightning node into two processes. The signer runs
 lnd with the seed and private keys but does not connect to the peer-to-peer
 network, does not route payments, and does not manage channels. The watch-only
-node does everything else.
+node does everything else. By default, both run in Docker containers
+(`litd-signer` and `litd` respectively); pass `--native` to scripts for local
+binary mode.
 
 ### Credential Bundle
 
@@ -164,6 +166,10 @@ For production deployments:
   signer.
 
   ```bash
+  # Container mode (auto-detects litd-signer)
+  skills/macaroon-bakery/scripts/bake.sh --role signer-only --container litd-signer
+
+  # Native mode
   skills/macaroon-bakery/scripts/bake.sh --role signer-only \
       --rpc-port 10012 --lnddir ~/.lnd-signer
   ```
@@ -251,7 +257,9 @@ Before deploying the kit with real funds:
    derivation permissions on the signer.
 
 4. **Firewall the signer.** Restrict port 10012 to the watch-only node's IP.
-   Restrict port 10013 (REST) to localhost.
+   In container mode, port 10013 (REST) is bound to `0.0.0.0` for Docker
+   networking but is only host-mapped during wallet setup. In native mode,
+   `setup-signer.sh` rebinds REST to `localhost`.
 
 5. **Secure credential files.** Verify that `wallet-password.txt`, `seed.txt`,
    and all `.macaroon` files have mode 0600. The kit's scripts set this
@@ -281,3 +289,10 @@ Every credential and secret file the kit manages:
 | `~/.lnd-signer/data/chain/bitcoin/<network>/admin.macaroon` | 0600 | Signer | Signer admin macaroon |
 | `~/.lnget/tokens/<domain>/` | 0700 | Agent | Cached L402 tokens |
 | `~/.aperture/aperture.yaml` | 0600 | Seller | Aperture config (may contain credentials) |
+
+**Container mode note:** In container deployments, daemon data directories
+(`~/.lnd/`, `~/.lnd-signer/`) live inside Docker volumes (`litd-data`,
+`signer-data`) rather than on the host filesystem. The host-side credential
+files under `~/.lnget/` remain the same in both modes. Use `docker cp` or
+`export-credentials.sh --container` to extract macaroons and TLS certs from
+running containers.

--- a/docs/two-agent-setup.md
+++ b/docs/two-agent-setup.md
@@ -46,7 +46,90 @@ The credentials bundle contains three files:
 No private keys cross the wire. The bundle contains only public keys and
 authentication material.
 
-## Part 1: Signer Agent (Secure Machine)
+## Container Mode (Recommended)
+
+Docker is the default deployment method. All scripts auto-detect containers
+and route commands through `docker exec`.
+
+### Signer Machine
+
+```bash
+# Pull the lnd signer image.
+skills/lightning-security-module/scripts/install.sh
+
+# Create the signer wallet and export the credentials bundle.
+# This launches the litd-signer container, creates the wallet via REST API,
+# and exports the bundle to ~/.lnget/signer/credentials-bundle/.
+skills/lightning-security-module/scripts/setup-signer.sh
+
+# Start the signer container (if not already running from setup).
+skills/lightning-security-module/scripts/start-signer.sh
+```
+
+Transfer the credentials bundle to the agent machine:
+
+```bash
+scp ~/.lnget/signer/credentials-bundle/credentials-bundle.tar.gz.b64 \
+    agent-machine:~/credentials-bundle.tar.gz.b64
+```
+
+### Agent Machine
+
+```bash
+# Pull the litd image.
+skills/lnd/scripts/install.sh
+
+# Import the signer's credentials bundle.
+skills/lnd/scripts/import-credentials.sh --bundle ~/credentials-bundle.tar.gz.b64
+
+# Create the watch-only wallet (auto-detects the litd container).
+skills/lnd/scripts/create-wallet.sh
+
+# Start in watch-only mode (launches litd + signer containers via Docker Compose).
+skills/lnd/scripts/start-lnd.sh --watchonly
+
+# Verify.
+skills/lnd/scripts/lncli.sh getinfo
+skills/lnd/scripts/lncli.sh newaddress p2tr
+```
+
+The `--watchonly` flag uses `docker-compose-watchonly.yml`, which starts both a
+litd container (watch-only) and connects it to the signer via the Docker
+network. The signer's gRPC address is pre-configured in the watch-only template
+(`lnd.remotesigner.rpchost=signer:10012`).
+
+### Container Lifecycle
+
+```bash
+# Stop containers.
+skills/lnd/scripts/stop-lnd.sh
+
+# Stop and remove volumes (destructive — removes chain data).
+skills/lnd/scripts/stop-lnd.sh --clean
+
+# On signer machine.
+skills/lightning-security-module/scripts/stop-signer.sh
+skills/lightning-security-module/scripts/stop-signer.sh --clean
+```
+
+### Scoping the Signer Macaroon (Container)
+
+```bash
+# On the signer machine, bake a scoped macaroon inside the container.
+skills/macaroon-bakery/scripts/bake.sh --role signer-only --container litd-signer
+
+# Re-export the credentials bundle with the scoped macaroon.
+skills/lightning-security-module/scripts/export-credentials.sh --container litd-signer
+```
+
+---
+
+## Native Mode
+
+For environments without Docker, all scripts accept a `--native` flag to use
+locally installed binaries.
+
+### Part 1: Signer Agent (Secure Machine)
 
 The signer agent runs on a machine with restricted access. This machine will
 hold all private keys and never connect to the Lightning Network directly.
@@ -54,17 +137,17 @@ hold all private keys and never connect to the Lightning Network directly.
 ### Install lnd
 
 ```bash
-skills/lightning-security-module/scripts/install.sh
+skills/lightning-security-module/scripts/install.sh --source
 ```
 
-This builds lnd with the signing-related build tags. The binary is the same as
-a regular lnd install, but the signer's configuration restricts it to signing
-operations only.
+This builds lnd from source with the signing-related build tags. The binary is
+the same as a regular lnd install, but the signer's configuration restricts it
+to signing operations only.
 
 ### Create the signer wallet and export credentials
 
 ```bash
-skills/lightning-security-module/scripts/setup-signer.sh
+skills/lightning-security-module/scripts/setup-signer.sh --native
 ```
 
 This does three things:
@@ -81,12 +164,12 @@ base64-encoded tarball (`credentials-bundle.tar.gz.b64`) for easy transfer.
 ### Start the signer
 
 ```bash
-skills/lightning-security-module/scripts/start-signer.sh
+skills/lightning-security-module/scripts/start-signer.sh --native
 ```
 
 The signer listens on port 10012 (gRPC) for signing requests from the
-watch-only node. It binds REST to localhost:10013 only. It does not connect to
-any peers and does not participate in the Lightning Network.
+watch-only node. In native mode, REST binds to `localhost:10013` only. It does
+not connect to any peers and does not participate in the Lightning Network.
 
 ### Transfer the bundle
 
@@ -122,7 +205,7 @@ Then re-export the credentials bundle with the scoped macaroon:
 skills/lightning-security-module/scripts/export-credentials.sh
 ```
 
-## Part 2: Node Agent (Agent Machine)
+### Part 2: Node Agent (Agent Machine)
 
 The node agent runs on the machine where agents will operate. This machine
 will have no private keys.
@@ -130,7 +213,7 @@ will have no private keys.
 ### Install lnd
 
 ```bash
-skills/lnd/scripts/install.sh
+skills/lnd/scripts/install.sh --source
 ```
 
 ### Import the credentials bundle
@@ -147,7 +230,7 @@ expects them.
 ### Create the watch-only wallet
 
 ```bash
-skills/lnd/scripts/create-wallet.sh \
+skills/lnd/scripts/create-wallet.sh --native \
     --signer-host <signer-ip>:10012
 ```
 
@@ -162,7 +245,7 @@ signer for initial key verification.
 ### Start the watch-only node
 
 ```bash
-skills/lnd/scripts/start-lnd.sh \
+skills/lnd/scripts/start-lnd.sh --native \
     --signer-host <signer-ip>:10012
 ```
 
@@ -272,14 +355,18 @@ The signer agent's role is maintenance: keeping the signer process running,
 rotating macaroons periodically, and backing up the seed.
 
 ```bash
-# On the signer machine
-skills/lightning-security-module/scripts/start-signer.sh    # if stopped
-skills/lightning-security-module/scripts/stop-signer.sh     # for maintenance
+# On the signer machine (container mode)
+skills/lightning-security-module/scripts/start-signer.sh    # delegates to docker-start.sh
+skills/lightning-security-module/scripts/stop-signer.sh     # delegates to docker-stop.sh
 
-# Rotate the signer macaroon
+# Rotate the signer macaroon (container)
+skills/macaroon-bakery/scripts/bake.sh --role signer-only --container litd-signer
+skills/lightning-security-module/scripts/export-credentials.sh --container litd-signer
+
+# Rotate the signer macaroon (native)
 skills/macaroon-bakery/scripts/bake.sh --role signer-only \
     --rpc-port 10012 --lnddir ~/.lnd-signer
-skills/lightning-security-module/scripts/export-credentials.sh
+skills/lightning-security-module/scripts/export-credentials.sh --native
 
 # Then transfer the new bundle to the node agent and re-import
 ```


### PR DESCRIPTION
## Summary

- Update all `docs/` files and `README.md` to reflect the container-first deployment model from PR #2.
- Docker is now documented as the default path; native mode is a documented fallback via `--native` flags.
- `docs/architecture.md`: rewrite Lightning Node section for litd containers, add config-gen/profile/versions.env docs, update file system layout for Docker volumes, add container ports.
- `docs/quickref.md`: add Docker lifecycle commands (`--watchonly`, `--regtest`, `--profile`, `--clean`), restructure Docker section as primary path.
- `docs/two-agent-setup.md`: add Container Mode (Recommended) section with full walkthrough, rename existing content to Native Mode.
- `docs/commerce.md`, `docs/security.md`, `README.md`: smaller container-first updates throughout.

## Test plan

- [ ] Read through each updated doc for broken internal links
- [ ] Verify script paths and flags match actual scripts
- [ ] Confirm mermaid diagrams render correctly on GitHub