### PR TITLE
npm + plugin: add npm distribution and Claude Code marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,36 @@
+{
+  "name": "lightninglabs",
+  "owner": {
+    "name": "Lightning Labs",
+    "email": "support@lightning.engineering"
+  },
+  "metadata": {
+    "description": "Lightning Network agent toolkit — MCP server, L402 payments, node operations, and composable skills for AI agents",
+    "version": "0.2.0"
+  },
+  "plugins": [
+    {
+      "name": "lightning-agent-tools",
+      "source": ".",
+      "description": "Full Lightning Network agent toolkit with 7 composable skills: lnd node operations, remote signer security, L402 commerce with lnget and Aperture, scoped macaroon credentials, and MCP server integration via Lightning Node Connect.",
+      "version": "0.2.0",
+      "author": {
+        "name": "Lightning Labs"
+      },
+      "homepage": "https://github.com/lightninglabs/lightning-agent-tools",
+      "repository": "https://github.com/lightninglabs/lightning-agent-tools",
+      "license": "MIT",
+      "keywords": [
+        "lightning",
+        "bitcoin",
+        "lnd",
+        "l402",
+        "payments",
+        "mcp",
+        "lnc",
+        "agent"
+      ],
+      "category": "infrastructure"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "lightning-agent-kit",
+  "name": "lightning-agent-tools",
   "description": "Lightning Network agent toolkit. Container-first skills for running Lightning Terminal (litd) nodes with lnd, loop, pool, and tapd. Includes remote signer security, L402 commerce with lnget and Aperture, scoped macaroon credentials, and MCP server integration.",
   "version": "0.2.0",
   "author": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION: "1.24.5"
+
+jobs:
+  # Cross-compile the MCP server binary for all supported platforms and
+  # attach them as release assets.
+  build:
+    name: Build ${{ matrix.sys }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - sys: linux-amd64
+            goos: linux
+            goarch: amd64
+          - sys: linux-arm64
+            goos: linux
+            goarch: arm64
+          - sys: darwin-amd64
+            goos: darwin
+            goarch: amd64
+          - sys: darwin-arm64
+            goos: darwin
+            goarch: arm64
+          - sys: windows-amd64
+            goos: windows
+            goarch: amd64
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+
+      # Build the MCP server binary with the target platform and
+      # architecture. The binary is named lightning-mcp-server inside
+      # the tarball so the npm postinstall script can extract it
+      # without renaming.
+      - name: Build binary
+        working-directory: mcp-server
+        run: |
+          COMMIT=$(git describe --abbrev=40 --always --dirty)
+          PKG=github.com/lightninglabs/lightning-agent-kit/mcp-server
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            EXT=".exe"
+          fi
+          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -v -trimpath \
+            -ldflags "-s -w -buildid= -X ${PKG}.Commit=${COMMIT}" \
+            -o lightning-mcp-server${EXT} .
+
+      # Package the binary into a tarball with a consistent name
+      # inside (lightning-mcp-server) so postinstall.js works on all
+      # platforms without renaming.
+      - name: Package tarball
+        working-directory: mcp-server
+        run: |
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            tar czf lightning-mcp-server-${{ matrix.sys }}.tar.gz \
+              lightning-mcp-server.exe
+          else
+            tar czf lightning-mcp-server-${{ matrix.sys }}.tar.gz \
+              lightning-mcp-server
+          fi
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: mcp-server/lightning-mcp-server-${{ matrix.sys }}.tar.gz
+          fail_on_unmatched_files: true
+
+  # After all platform binaries are uploaded, publish the npm package.
+  # The postinstall script will download the correct binary for each
+  # user's platform from the GitHub Release assets.
+  #
+  # Uses npm Trusted Publishers (OIDC) — no NPM_TOKEN secret needed.
+  # Configure at: npmjs.com → package settings → Trusted publishing.
+  publish-npm:
+    name: Publish npm
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      # Sync the npm package version to the git tag so the
+      # postinstall script downloads the matching release.
+      - name: Set npm version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '${VERSION}';
+            require('fs').writeFileSync(
+              'package.json',
+              JSON.stringify(pkg, null, 2) + '\n'
+            );
+          "
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing uses OIDC — npm CLI automatically detects
+      # the GitHub Actions environment and authenticates via id-token.
+      # Provenance attestations are generated automatically.
+      - name: Publish to npm
+        run: npm publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,10 @@ lightning-mcp-server/lightning-mcp-server
 lightning-mcp-server/coverage.out
 lightning-mcp-server/coverage.html
 
+# npm artifacts
+node_modules/
+bin/lightning-mcp-server
+!bin/lightning-mcp-server.placeholder
+
 # Credentials (never commit)
 *.macaroon

--- a/README.md
+++ b/README.md
@@ -20,6 +20,34 @@ and works with any compatible client. The security model defaults to a remote
 signer architecture that keeps private keys on a separate machine, away from the
 agent's runtime environment.
 
+## Install
+
+**MCP server** (zero-install, any MCP client):
+
+```bash
+claude mcp add --transport stdio lnc -- npx -y @lightninglabs/lightning-mcp-server
+```
+
+**Full plugin** (all 7 skills via Claude Code):
+
+```bash
+claude plugin marketplace add lightninglabs/lightning-agent-tools
+claude plugin install lightning-agent-tools@lightninglabs
+```
+
+**From source** (requires Go 1.24+):
+
+```bash
+git clone https://github.com/lightninglabs/lightning-agent-tools.git
+cd lightning-agent-tools
+skills/lightning-mcp-server/scripts/install.sh
+skills/lightning-mcp-server/scripts/configure.sh --production
+skills/lightning-mcp-server/scripts/setup-claude-config.sh --scope project
+```
+
+See [Quick Start](#quick-start) below for detailed setup options including
+environment variables, regtest mode, and the full commerce stack.
+
 ## How It Works
 
 ```mermaid
@@ -128,10 +156,10 @@ plugin marketplace:
 
 ```bash
 # Add the marketplace (one-time)
-/plugin marketplace add lightninglabs/lightning-agent-tools
+claude plugin marketplace add lightninglabs/lightning-agent-tools
 
 # Install the plugin (gets all skills)
-/plugin install lightning-agent-tools@lightninglabs
+claude plugin install lightning-agent-tools@lightninglabs
 ```
 
 Or load locally for development:
@@ -167,7 +195,7 @@ Connect to my Lightning node with pairing phrase: "word1 word2 ... word10"
 The agent can now query balances, list channels, decode invoices, and inspect
 the network graph. See [MCP Server](docs/mcp-server.md) for details.
 
-### Option B: Full Commerce Stack
+### Option D: Full Commerce Stack
 
 Run your own node and start buying or selling resources over Lightning. Docker
 is the default deployment method — `install.sh` pulls a container image and

--- a/README.md
+++ b/README.md
@@ -82,15 +82,76 @@ tools for querying node state and works with any MCP-compatible client.
 
 ## Quick Start
 
-### Option A: Read-Only Node Access (MCP)
+### Option A: Zero-Install MCP via `claude mcp add`
 
-The fastest path to interacting with a Lightning node. Requires a node running
-[Lightning Terminal](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/get-lit)
-and a pairing phrase.
+Register the MCP server with Claude Code in one command — no Go toolchain or
+git clone required:
 
 ```bash
-git clone https://github.com/lightninglabs/lightning-agent-kit.git
-cd lightning-agent-kit
+claude mcp add --transport stdio lnc -- npx -y @lightninglabs/lightning-mcp-server
+```
+
+With a specific mailbox server:
+
+```bash
+claude mcp add --transport stdio \
+  --env LNC_MAILBOX_SERVER=mailbox.terminal.lightning.today:443 \
+  lnc -- npx -y @lightninglabs/lightning-mcp-server
+```
+
+For development/regtest:
+
+```bash
+claude mcp add --transport stdio \
+  --env LNC_MAILBOX_SERVER=localhost:11110 \
+  --env LNC_DEV_MODE=true \
+  --env LNC_INSECURE=true \
+  lnc -- npx -y @lightninglabs/lightning-mcp-server
+```
+
+Scope options: `--scope local` (default, just you), `--scope project` (shared
+via `.mcp.json`), `--scope user` (all your projects).
+
+Restart Claude Code, then:
+
+```
+Connect to my Lightning node with pairing phrase: "word1 word2 ... word10"
+```
+
+The agent can now query balances, list channels, decode invoices, and inspect
+the network graph. See [MCP Server](docs/mcp-server.md) for details.
+
+### Option B: Full Plugin with All Skills
+
+Install the complete plugin (all 7 skills + MCP server) via the Claude Code
+plugin marketplace:
+
+```bash
+# Add the marketplace (one-time)
+/plugin marketplace add lightninglabs/lightning-agent-tools
+
+# Install the plugin (gets all skills)
+/plugin install lightning-agent-tools@lightninglabs
+```
+
+Or load locally for development:
+
+```bash
+git clone https://github.com/lightninglabs/lightning-agent-tools.git
+claude --plugin-dir ./lightning-agent-tools
+```
+
+This gives Claude Code access to all skills: lnd node management, remote
+signer security, lnget L402 payments, Aperture proxy, macaroon bakery,
+MCP server integration, and commerce workflows.
+
+### Option C: Read-Only Node Access (from source)
+
+Build the MCP server from source. Requires Go 1.24+.
+
+```bash
+git clone https://github.com/lightninglabs/lightning-agent-tools.git
+cd lightning-agent-tools
 
 skills/lightning-mcp-server/scripts/install.sh
 skills/lightning-mcp-server/scripts/configure.sh --production
@@ -113,8 +174,8 @@ is the default deployment method — `install.sh` pulls a container image and
 `start-lnd.sh` launches it via Docker Compose.
 
 ```bash
-git clone https://github.com/lightninglabs/lightning-agent-kit.git
-cd lightning-agent-kit
+git clone https://github.com/lightninglabs/lightning-agent-tools.git
+cd lightning-agent-tools
 
 # Install components (pulls Docker images by default; --source to build natively)
 skills/lnd/scripts/install.sh

--- a/bin/lightning-mcp-server
+++ b/bin/lightning-mcp-server
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# This wrapper script is a placeholder that gets replaced by the actual
+# binary during npm postinstall. If you see this message, the postinstall
+# script did not run successfully.
+#
+# To fix this, try:
+#   npm rebuild @lightninglabs/lightning-mcp-server
+#
+# Or build from source:
+#   cd mcp-server && make build
+
+echo "Error: lightning-mcp-server binary not installed." >&2
+echo "Run 'npm rebuild @lightninglabs/lightning-mcp-server' or build from source." >&2
+exit 1

--- a/package.json
+++ b/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@lightninglabs/lightning-mcp-server",
+  "version": "0.2.0",
+  "description": "Lightning Network agent toolkit for Claude Code — MCP server, L402 payments, node operations, and 7 composable skills",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lightninglabs/lightning-agent-kit"
+  },
+  "homepage": "https://github.com/lightninglabs/lightning-agent-kit#quick-start",
+  "keywords": [
+    "lightning",
+    "lightning-network",
+    "lnc",
+    "l402",
+    "mcp",
+    "claude-code",
+    "bitcoin",
+    "lnd",
+    "aperture",
+    "agent"
+  ],
+  "bin": {
+    "lightning-mcp-server": "./bin/lightning-mcp-server"
+  },
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  },
+  "files": [
+    "bin/",
+    "skills/",
+    "docs/",
+    ".claude-plugin/",
+    ".claude/",
+    "postinstall.js",
+    "versions.env",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ]
+}

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+// postinstall.js downloads the pre-built lightning-mcp-server binary for the
+// current platform and architecture from GitHub Releases. This follows the
+// same pattern used by esbuild, turbo, and other Go/Rust projects distributed
+// via npm.
+//
+// The binary is placed in bin/ so the npm "bin" entry in package.json can
+// reference it directly, making `npx lightning-mcp-server` work out of the
+// box.
+
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+const os = require("os");
+
+// PLATFORM_MAP translates Node.js platform/arch identifiers to the Go build
+// system naming convention used by the release workflow.
+const PLATFORM_MAP = {
+	"darwin-arm64": "darwin-arm64",
+	"darwin-x64": "darwin-amd64",
+	"linux-arm64": "linux-arm64",
+	"linux-x64": "linux-amd64",
+	"win32-x64": "windows-amd64",
+};
+
+// REPO is the GitHub repository that hosts the release binaries.
+const REPO = "lightninglabs/lightning-agent-kit";
+
+// BINARY_NAME is the name of the binary inside the release tarball.
+const BINARY_NAME = "lightning-mcp-server";
+
+// getPackageVersion reads the version from package.json to determine which
+// GitHub release tag to download from.
+function getPackageVersion() {
+	const pkg = JSON.parse(
+		fs.readFileSync(path.join(__dirname, "package.json"), "utf8"),
+	);
+	return pkg.version;
+}
+
+// getPlatformKey returns the platform-architecture key for the current
+// system, e.g. "darwin-arm64" or "linux-x64".
+function getPlatformKey() {
+	const platform = os.platform();
+	const arch = os.arch();
+	return `${platform}-${arch}`;
+}
+
+// getBinaryPath returns the file path where the downloaded binary will be
+// placed within the package's bin directory.
+function getBinaryPath() {
+	const ext = os.platform() === "win32" ? ".exe" : "";
+	return path.join(__dirname, "bin", `${BINARY_NAME}${ext}`);
+}
+
+// fetchBuffer follows HTTP redirects (GitHub Releases redirects to a CDN)
+// and returns the final response body as a buffer.
+function fetchBuffer(url) {
+	return new Promise((resolve, reject) => {
+		const opts = { headers: { "User-Agent": "npm-postinstall" } };
+		https.get(url, opts, (res) => {
+			if (res.statusCode >= 300 && res.statusCode < 400 &&
+				res.headers.location) {
+				fetchBuffer(res.headers.location)
+					.then(resolve, reject);
+				return;
+			}
+			if (res.statusCode !== 200) {
+				reject(new Error(
+					`Download failed: HTTP ${res.statusCode} ` +
+					`from ${url}`,
+				));
+				return;
+			}
+			const chunks = [];
+			res.on("data", (chunk) => chunks.push(chunk));
+			res.on("end", () => resolve(Buffer.concat(chunks)));
+			res.on("error", reject);
+		}).on("error", reject);
+	});
+}
+
+// extractTarGz extracts a .tar.gz buffer to the specified directory using
+// the system tar command. The binary is expected at the root of the archive.
+function extractTarGz(buffer, destDir) {
+	const tmpFile = path.join(
+		os.tmpdir(), `${BINARY_NAME}-${Date.now()}.tar.gz`,
+	);
+	fs.writeFileSync(tmpFile, buffer);
+	try {
+		execSync(`tar xzf "${tmpFile}" -C "${destDir}"`, {
+			stdio: "pipe",
+		});
+	} finally {
+		fs.unlinkSync(tmpFile);
+	}
+}
+
+// main downloads and installs the correct binary for the current platform.
+async function main() {
+	const platformKey = getPlatformKey();
+	const goTarget = PLATFORM_MAP[platformKey];
+
+	if (!goTarget) {
+		console.error(
+			`Unsupported platform: ${platformKey}. ` +
+			`Supported: ${Object.keys(PLATFORM_MAP).join(", ")}`,
+		);
+		console.error(
+			"You can build from source instead:\n" +
+			"  cd mcp-server && make build",
+		);
+		process.exit(1);
+	}
+
+	const version = getPackageVersion();
+	const tag = `v${version}`;
+	const assetName = `${BINARY_NAME}-${goTarget}.tar.gz`;
+	const url =
+		`https://github.com/${REPO}/releases/download/${tag}/${assetName}`;
+
+	console.log(
+		`Downloading ${BINARY_NAME} ${tag} for ${goTarget}...`,
+	);
+
+	try {
+		const buffer = await fetchBuffer(url);
+
+		// Ensure the bin directory exists before extracting.
+		const binDir = path.join(__dirname, "bin");
+		fs.mkdirSync(binDir, { recursive: true });
+
+		extractTarGz(buffer, binDir);
+
+		// Make the binary executable on Unix systems.
+		const binaryPath = getBinaryPath();
+		if (os.platform() !== "win32") {
+			fs.chmodSync(binaryPath, 0o755);
+		}
+
+		console.log(`Installed ${BINARY_NAME} to ${binaryPath}`);
+	} catch (err) {
+		console.error(
+			`Failed to download ${BINARY_NAME}: ${err.message}`,
+		);
+		console.error("");
+		console.error("You can build from source instead:");
+		console.error("  cd mcp-server && make build");
+		console.error("");
+		console.error(
+			"Or download from: " +
+			`https://github.com/${REPO}/releases/tag/${tag}`,
+		);
+		process.exit(1);
+	}
+}
+
+main();

--- a/skills/lightning-mcp-server/SKILL.md
+++ b/skills/lightning-mcp-server/SKILL.md
@@ -82,6 +82,32 @@ Configuration is stored in `lightning-mcp-server/.env`. Key settings:
 
 ## Claude Code Integration
 
+### Option 1: `claude mcp add` (recommended)
+
+Register the MCP server with a single command — no build step required:
+
+```bash
+# Zero-install via npx (downloads pre-built binary)
+claude mcp add --transport stdio lnc -- npx -y @lightninglabs/lightning-mcp-server
+
+# With environment variables for production
+claude mcp add --transport stdio \
+  --env LNC_MAILBOX_SERVER=mailbox.terminal.lightning.today:443 \
+  lnc -- npx -y @lightninglabs/lightning-mcp-server
+
+# For development/regtest
+claude mcp add --transport stdio \
+  --env LNC_MAILBOX_SERVER=localhost:11110 \
+  --env LNC_DEV_MODE=true \
+  --env LNC_INSECURE=true \
+  lnc -- npx -y @lightninglabs/lightning-mcp-server
+```
+
+Scope options: `--scope local` (default, just you), `--scope project` (shared
+via `.mcp.json`), `--scope user` (all your projects).
+
+### Option 2: Setup script (from source)
+
 ```bash
 # Add lightning-mcp-server to Claude Code's MCP config
 skills/lightning-mcp-server/scripts/setup-claude-config.sh
@@ -97,9 +123,25 @@ This adds the server to Claude Code's `.mcp.json` (project) or
 `~/.claude.json` (global) configuration. After restarting Claude Code, the
 LNC tools will be available.
 
-### Manual Configuration
+### Option 3: Manual configuration
 
 Add to `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "lnc": {
+      "command": "npx",
+      "args": ["-y", "@lightninglabs/lightning-mcp-server"],
+      "env": {
+        "LNC_MAILBOX_SERVER": "mailbox.terminal.lightning.today:443"
+      }
+    }
+  }
+}
+```
+
+Or with a locally built binary:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Add npm package `@lightninglabs/lightning-mcp-server` that distributes the MCP server binary via postinstall download from GitHub Releases (same pattern as esbuild/turbo)
- Add Claude Code plugin marketplace manifest (`lightninglabs` org) for installing all 7 skills via `/plugin install lightning-agent-tools@lightninglabs`
- Add GitHub Actions release workflow that cross-compiles for 5 platforms and publishes to npm via OIDC Trusted Publishers (no NPM_TOKEN secret needed)
- Rewrite Quick Start with three paths: zero-install via `claude mcp add` + npx, full plugin via marketplace, and build-from-source

## Test plan

- [ ] Verify `npm pack` includes expected files (package.json, postinstall.js, bin/, skills/, .claude-plugin/)
- [ ] Tag a release and verify the CI workflow builds all 5 platform tarballs
- [ ] Verify npm Trusted Publishers OIDC publish works end-to-end
- [ ] Test `npx -y @lightninglabs/lightning-mcp-server` downloads and runs the binary
- [ ] Test `claude mcp add --transport stdio lnc -- npx -y @lightninglabs/lightning-mcp-server` registers correctly
- [ ] Test `/plugin marketplace add lightninglabs/lightning-agent-tools` + `/plugin install` works