### PR TITLE
Update lnget skill docs for dashboard and API server

### DIFF
--- a/docs/quickref.md
+++ b/docs/quickref.md
@@ -136,6 +136,11 @@ lnget ln lnc revoke <session-id>                           # revoke session
 lnget ln neutrino init                                     # initialize
 lnget ln neutrino fund                                     # funding address
 lnget ln neutrino balance                                  # check balance
+
+# Dashboard & API server
+lnget serve                                                # start API (localhost:2402)
+lnget serve --addr localhost:2402                           # custom address
+cd dashboard && yarn dev                                   # start dashboard (localhost:3001)
 ```
 
 ## Aperture
@@ -242,6 +247,7 @@ skills/macaroon-bakery/scripts/bake.sh --role pay-only \
 | `~/.lnget/signer/credentials-bundle/` | Exported signer credentials |
 | `~/.lnget/config.yaml` | lnget configuration |
 | `~/.lnget/tokens/<domain>/` | L402 cached tokens |
+| `~/.lnget/events.db` | Payment event log (SQLite) |
 | `~/.lnd/` | lnd data (chain, macaroons, TLS) |
 | `~/.lnd/data/chain/bitcoin/<network>/admin.macaroon` | Admin macaroon |
 | `~/.lnd/tls.cert` | lnd TLS certificate |

--- a/skills/lnget/SKILL.md
+++ b/skills/lnget/SKILL.md
@@ -284,11 +284,65 @@ lnget --json https://api.example.com/data.json | jq '.l402_paid'
 lnget -k https://localhost:8081/api/data
 ```
 
+## Dashboard and API Server
+
+lnget includes an event logger, REST API server, and web dashboard for
+monitoring L402 spending activity.
+
+### Event Logging
+
+All L402 payment events are automatically recorded to `~/.lnget/events.db`
+(SQLite). This is enabled by default:
+
+```yaml
+events:
+  enabled: true
+  db_path: ~/.lnget/events.db
+```
+
+### API Server (`lnget serve`)
+
+```bash
+# Start the API server
+lnget serve
+
+# Custom address
+lnget serve --addr localhost:2402
+```
+
+Endpoints:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/events` | List events (query: limit, offset, domain, status) |
+| `GET /api/events/stats` | Aggregate spending statistics |
+| `GET /api/events/domains` | Per-domain spending breakdown |
+| `GET /api/tokens` | List all cached tokens |
+| `DELETE /api/tokens/:domain` | Remove a token |
+| `GET /api/status` | Lightning backend connection status |
+| `GET /api/config` | Current config (sensitive fields redacted) |
+
+### Web Dashboard
+
+```bash
+cd dashboard
+yarn install
+yarn dev
+# Open http://localhost:3001
+```
+
+Pages:
+- **Dashboard** — Total spent, payment count, active tokens, wallet balance, charts
+- **Tokens** — Cached L402 tokens with management actions
+- **Payments** — Paginated event log with filters and volume chart
+- **Status** — Lightning backend info and configuration overview
+
 ## File Locations
 
 | Path | Purpose |
 |------|---------|
 | `~/.lnget/config.yaml` | Configuration file |
 | `~/.lnget/tokens/<domain>/` | Per-domain token storage |
+| `~/.lnget/events.db` | Payment event log (SQLite) |
 | `~/.lnget/lnc/sessions/` | LNC session persistence |
 | `~/.lnget/neutrino/` | Embedded wallet data |


### PR DESCRIPTION
## Summary

- Update `skills/lnget/SKILL.md` with new Dashboard and API Server section documenting `lnget serve` command, REST API endpoints, event logging config, and dashboard setup
- Update `docs/quickref.md` with `lnget serve` commands and `events.db` file path
- Companion to lightninglabs/lnget consumer-dashboard PR

## Test plan

- [x] Verify SKILL.md renders correctly
- [x] Verify quickref.md commands are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)