### PR TITLE
docs: add live Maximum Sats L402 usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ production checklist.
 |----------|-------------|
 | [Architecture](docs/architecture.md) | System design, component map, plugin discovery, data flows |
 | [Security](docs/security.md) | Three-tier security model, remote signer, macaroon scoping, production checklist |
-| [L402 and lnget](docs/l402-and-lnget.md) | The L402 protocol, lnget usage, spending controls, token caching |
+| [L402 and lnget](docs/l402-and-lnget.md) | The L402 protocol, lnget usage, spending controls, token caching, and a live paid endpoint example |
 | [MCP Server](docs/mcp-server.md) | LNC mechanics, setup walkthrough, 18-tool reference, configuration |
 | [Commerce](docs/commerce.md) | Buyer and seller agent setup, the commerce loop, cost management |
 | [Two-Agent Setup](docs/two-agent-setup.md) | Signer agent + node agent walkthrough for production key isolation |

--- a/docs/l402-and-lnget.md
+++ b/docs/l402-and-lnget.md
@@ -251,6 +251,31 @@ lnget ln info
 lnget tokens list --json | jq '[.[] | .amount_paid_sat] | add'
 ```
 
+## Live Endpoint Example: Maximum Sats DVM
+
+Use this to test a real paid endpoint end-to-end.
+
+```bash
+# 1) Probe the challenge without paying (HTTP 402 + WWW-Authenticate: L402)
+curl -sS -i -X POST https://maximumsats.com/api/dvm \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"Summarize NIP-85 in one sentence."}' | sed -n '1,20p'
+
+# 2) Preview with lnget (no payment, challenge details only)
+lnget --no-pay --max-cost 30 -X POST \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"Summarize NIP-85 in one sentence."}' \
+  https://maximumsats.com/api/dvm
+
+# 3) Pay and execute (auto-pays if invoice <= --max-cost)
+lnget --max-cost 30 -X POST \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"Summarize NIP-85 in one sentence."}' \
+  https://maximumsats.com/api/dvm
+```
+
+If `--max-cost` is below the invoice amount, lnget exits before paying.
+
 ## The Server Side: Aperture
 
 lnget handles the client side of L402. On the server side,


### PR DESCRIPTION
## Summary
- adds a concrete, copy-pasteable live endpoint example to `docs/l402-and-lnget.md`
- demonstrates the full flow against `https://maximumsats.com/api/dvm`:
  - challenge probe (`curl` + expected `402`)
  - `lnget --no-pay` preview
  - `lnget` paid execution with `--max-cost`
- updates the README docs table to call out the live paid endpoint example

## Why
Most examples are currently placeholder domains (`api.example.com`). This adds one real-world walkthrough so users can validate L402 behavior end-to-end with a known public endpoint.

## Validation
- `curl -i -X POST https://maximumsats.com/api/dvm ...` returns `HTTP/2 402` and `WWW-Authenticate: L402`
- `cd lightning-mcp-server && make unit` (pass)
- `cd lightning-mcp-server && make build` (pass)
