### PR TITLE
docs: add satring.com service discovery for L402 endpoints

### DIFF
--- a/docs/commerce.md
+++ b/docs/commerce.md
@@ -54,6 +54,32 @@ From the seller's perspective, aperture handles everything: invoice
 generation, challenge issuance, token validation, and request proxying. The
 backend service just serves HTTP requests.
 
+## Discovering Services
+
+Before a buyer agent can fetch paid resources, it needs to know what's
+available. [satring.com](https://satring.com) is a public directory of L402 and
+x402 API services with health monitoring, ratings, and pricing. Agents can query
+it programmatically to find endpoints:
+
+```bash
+# Find live L402 services in a category
+lnget -q "https://satring.com/api/v1/services?category=data&protocol=L402&status=live" \
+  | jq '.services[]'
+
+# Search by keyword
+lnget -q "https://satring.com/api/v1/search?q=inference&protocol=L402" | jq '.services[]'
+
+# Preview what a discovered service charges (without paying)
+lnget --no-pay --json https://discovered-service.com/api/endpoint | jq '.invoice_amount_sat'
+
+# If the price is acceptable, fetch the resource
+lnget --max-cost 500 https://discovered-service.com/api/endpoint
+```
+
+For sellers, listing your aperture-gated API on satring.com makes it
+discoverable by any agent in the ecosystem. Submit a service at
+[satring.com/submit](https://satring.com/submit) or via the API.
+
 ## Buyer Agent Setup
 
 A buyer agent needs two components: an `lnd` node for payments and `lnget` for

--- a/docs/l402-and-lnget.md
+++ b/docs/l402-and-lnget.md
@@ -65,6 +65,62 @@ instantly. This is what makes L402 native to agent workflows: agents can
 discover and pay for resources on the fly without requiring a human to pre-register
 accounts.
 
+## Service Discovery
+
+An agent using `lnget` needs to know _where_ to find L402-protected resources.
+[satring.com](https://satring.com) is a public directory of L402 (and
+[x402](https://www.x402.org/)) API services with live health monitoring, ratings,
+and pricing metadata. Agents can query it to discover endpoints before paying.
+
+### Browsing the Directory
+
+The satring API is open for basic queries (no payment required for search):
+
+```bash
+# List all live L402 services
+lnget -q "https://satring.com/api/v1/services?protocol=L402&status=live" | jq '.services[]'
+
+# Filter by category (ai-ml, data, finance, identity, media, search, social, storage, tools)
+lnget -q "https://satring.com/api/v1/services?category=ai-ml&protocol=L402" | jq '.services[]'
+
+# Full-text search by name or description
+lnget -q "https://satring.com/api/v1/search?q=inference&protocol=L402" | jq '.services[]'
+```
+
+Each service entry includes its URL, pricing (in sats and USD), protocol (`L402`
+or `X402`), categories, average rating, and health status. Filter parameters
+`protocol` (`L402` or `X402`) and `status` (`live`, `confirmed`, `unverified`,
+`dead`) can be combined freely.
+
+### Discovery-then-Purchase Workflow
+
+An agent can chain directory lookup with `lnget` to find and pay for a resource
+in two steps:
+
+```bash
+# Step 1: Find a live data API under 500 sats
+SERVICE_URL=$(lnget -q "https://satring.com/api/v1/services?category=data&protocol=L402&status=live" \
+  | jq -r '.services[] | select(.pricing_sats <= 500) | .url' | head -1)
+
+# Step 2: Fetch the discovered endpoint
+lnget --max-cost 500 "$SERVICE_URL"
+```
+
+### Paid Analytics and Reputation
+
+Deeper directory data (analytics, reputation scores) is payment-gated via L402:
+
+```bash
+# Directory-wide analytics (L402-gated)
+lnget --max-cost 50 https://satring.com/api/v1/analytics | jq .
+
+# Per-service reputation report (L402-gated)
+lnget --max-cost 50 https://satring.com/api/v1/services/example-api/reputation | jq .
+```
+
+Satring itself uses L402 for premium endpoints, so `lnget` handles the payment
+flow transparently.
+
 ## lnget
 
 `lnget` automates the entire L402 flow in a single command:

--- a/skills/commerce/SKILL.md
+++ b/skills/commerce/SKILL.md
@@ -81,7 +81,22 @@ lnget config init
 lnget ln status
 ```
 
-### Step 6: Fetch Paid Resources
+### Step 6: Discover Services
+
+Agents can find L402 endpoints programmatically via
+[satring.com](https://satring.com), a public directory of L402 and x402 API
+services:
+
+```bash
+# Browse live L402 services by category
+lnget -q "https://satring.com/api/v1/services?category=data&protocol=L402&status=live" \
+  | jq '.services[]'
+
+# Search by keyword
+lnget -q "https://satring.com/api/v1/search?q=inference&protocol=L402" | jq '.services[]'
+```
+
+### Step 7: Fetch Paid Resources
 
 ```bash
 # Fetch an L402-protected resource
@@ -94,7 +109,7 @@ lnget --no-pay https://api.example.com/paid-data
 lnget tokens list
 ```
 
-### Step 7: Host Paid Endpoints (Optional)
+### Step 8: Host Paid Endpoints (Optional)
 
 ```bash
 # Start your backend service


### PR DESCRIPTION
## Summary

- Add **Service Discovery** section to `docs/l402-and-lnget.md` showing how agents can query satring.com to find L402 endpoints before paying
- Add **Discovering Services** step to `docs/commerce.md` buyer workflow, filling the gap where every example assumes the agent already knows the seller's URL
- Add **Step 6: Discover Services** to `skills/commerce/SKILL.md` with copy-pasteable `lnget` commands

## Context

`lnget` handles the L402 payment flow, but agents have no way to find L402 services programmatically. [satring.com](https://satring.com) is a public directory of L402 API services with health monitoring, ratings, and pricing. This PR connects the two: satring for discovery, lnget for payment.
