### PR TITLE
tests: add missing test lib helpers and mocks

### DIFF
--- a/tests/lib/helpers.sh
+++ b/tests/lib/helpers.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Test helper functions: assertions, progress tracking, summary.
+#
+# Usage:
+#   source tests/lib/helpers.sh
+#
+# Provides:
+#   REPO_ROOT           - absolute path to the repository root
+#   begin_test NAME     - start a test case
+#   end_test            - finish the current test case
+#   assert_eq A B MSG   - fail if A != B
+#   assert_neq A B MSG  - fail if A == B
+#   assert_contains HAYSTACK NEEDLE MSG - fail if NEEDLE not in HAYSTACK
+#   print_header LABEL  - print a section header
+#   print_summary       - print pass/fail totals; exit non-zero on failures
+
+HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HELPERS_DIR/../.." && pwd)"
+
+# Counters.
+_TESTS_RUN=0
+_TESTS_PASSED=0
+_TESTS_FAILED=0
+_CURRENT_TEST=""
+
+# Color codes (disabled when stdout is not a terminal).
+if [ -t 1 ]; then
+    _GREEN='\033[0;32m'
+    _RED='\033[0;31m'
+    _YELLOW='\033[0;33m'
+    _BOLD='\033[1m'
+    _RESET='\033[0m'
+else
+    _GREEN=''
+    _RED=''
+    _YELLOW=''
+    _BOLD=''
+    _RESET=''
+fi
+
+# begin_test starts a test case. Must be followed by end_test.
+begin_test() {
+    _CURRENT_TEST="$1"
+    _CURRENT_FAILED=false
+    (( _TESTS_RUN++ )) || true
+}
+
+# end_test finishes the current test case and prints the result.
+end_test() {
+    if [ "$_CURRENT_FAILED" = true ]; then
+        printf "  ${_RED}FAIL${_RESET} %s\n" "$_CURRENT_TEST"
+    else
+        (( _TESTS_PASSED++ )) || true
+        printf "  ${_GREEN}PASS${_RESET} %s\n" "$_CURRENT_TEST"
+    fi
+    _CURRENT_TEST=""
+}
+
+# _fail records a failure for the current test.
+_fail() {
+    local msg="$1"
+    _CURRENT_FAILED=true
+    (( _TESTS_FAILED++ )) || true
+    printf "       ${_RED}=> %s${_RESET}\n" "$msg" >&2
+}
+
+# assert_eq fails if the two values are not equal.
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local msg="${3:-expected '$expected', got '$actual'}"
+    if [ "$actual" != "$expected" ]; then
+        _fail "$msg (expected '$expected', got '$actual')"
+    fi
+}
+
+# assert_neq fails if the two values are equal.
+assert_neq() {
+    local actual="$1"
+    local unexpected="$2"
+    local msg="${3:-expected value other than '$unexpected'}"
+    if [ "$actual" = "$unexpected" ]; then
+        _fail "$msg (got '$actual')"
+    fi
+}
+
+# assert_contains fails if the haystack does not contain the needle
+# (case-insensitive grep).
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local msg="${3:-output should contain '$needle'}"
+    if ! echo "$haystack" | grep -qi "$needle"; then
+        _fail "$msg"
+    fi
+}
+
+# print_header prints a section divider.
+print_header() {
+    local label="$1"
+    printf "\n${_BOLD}── %s ──${_RESET}\n" "$label"
+}
+
+# print_summary prints the final tally and exits non-zero on failures.
+print_summary() {
+    echo ""
+    printf "${_BOLD}Results:${_RESET} "
+    printf "%d tests, " "$_TESTS_RUN"
+    printf "${_GREEN}%d passed${_RESET}, " "$_TESTS_PASSED"
+    printf "${_RED}%d failed${_RESET}\n" "$_TESTS_FAILED"
+
+    if [ "$_TESTS_FAILED" -gt 0 ]; then
+        exit 1
+    fi
+}

--- a/tests/lib/mocks.sh
+++ b/tests/lib/mocks.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Mock functions for unit tests.
+#
+# Replaces external commands (docker, lncli, etc.) with stubs so that
+# tests can exercise flag-parsing logic without Docker or a running node.
+#
+# Usage:
+#   source tests/lib/mocks.sh
+#   setup_mocks          # create a temp bin dir and prepend it to PATH
+#   mock_docker_ps TEXT  # make `docker ps` return TEXT
+#   teardown_mocks       # remove the temp dir and restore PATH
+
+_MOCK_DIR=""
+_ORIG_PATH=""
+
+# setup_mocks creates a temporary directory for mock executables and
+# prepends it to PATH so they shadow the real binaries.
+setup_mocks() {
+    _MOCK_DIR="$(mktemp -d)"
+    _ORIG_PATH="$PATH"
+    export PATH="$_MOCK_DIR:$PATH"
+
+    # Default docker mock: succeed for any command but produce no output.
+    _write_mock "docker" '#!/usr/bin/env bash
+# Default docker mock — exits 0 silently.
+# Overridden per-test via mock_docker_ps, etc.
+exit 0
+'
+
+    # Default docker-compose mock.
+    _write_mock "docker-compose" '#!/usr/bin/env bash
+exit 0
+'
+
+    # lncli mock — the test scripts never call lncli directly during
+    # flag parsing, but some scripts probe for it.
+    _write_mock "lncli" '#!/usr/bin/env bash
+echo "mock lncli"
+exit 0
+'
+}
+
+# teardown_mocks removes the mock directory and restores PATH.
+teardown_mocks() {
+    if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+        rm -rf "$_MOCK_DIR"
+    fi
+    if [ -n "$_ORIG_PATH" ]; then
+        export PATH="$_ORIG_PATH"
+    fi
+}
+
+# mock_docker_ps configures the docker mock so that `docker ps` returns
+# the given text. Other docker subcommands still exit 0 silently.
+mock_docker_ps() {
+    local output="$1"
+    _write_mock "docker" "#!/usr/bin/env bash
+if [[ \"\$1\" == \"ps\" ]]; then
+    echo '$output'
+    exit 0
+fi
+# For 'docker port', return empty (no running containers).
+if [[ \"\$1\" == \"port\" ]]; then
+    exit 0
+fi
+# For 'docker pull', 'docker run', etc. — succeed silently.
+exit 0
+"
+}
+
+# _write_mock writes a mock script to the mock directory.
+_write_mock() {
+    local name="$1"
+    local body="$2"
+    local path="$_MOCK_DIR/$name"
+    echo "$body" > "$path"
+    chmod +x "$path"
+}


### PR DESCRIPTION
`tests/unit/test_flag_parsing.sh` sources `tests/lib/helpers.sh` and `tests/lib/mocks.sh`, but neither file exists on `main`, so the unit suite exits before running.

This adds:

- assertion and test-lifecycle helpers with summary exit propagation;
- isolated command mocks for Docker, docker-compose, and lncli;
- configurable `docker ps` output for individual cases.

## Verification

Rebased onto current `main` and run under WSL from an LF checkout:

- `bash tests/unit/test_flag_parsing.sh`
- 74 tests passed, 0 failed.