### PR TITLE
docs: add real L402 API examples from LightningFaucet registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ production checklist.
 | [Commerce](docs/commerce.md) | Buyer and seller agent setup, the commerce loop, cost management |
 | [Two-Agent Setup](docs/two-agent-setup.md) | Signer agent + node agent walkthrough for production key isolation |
 | [Quick Reference](docs/quickref.md) | Every command in one place |
+| [L402 API Examples](docs/l402-api-examples.md) | Real-world L402 API examples from the LightningFaucet registry |
+
+### L402 API Directory
+
+- [LightningFaucet L402 Registry](https://lightningfaucet.com/l402-registry) — curated directory of live L402 APIs for testing and production use
 
 Each skill also has a detailed `SKILL.md` in its directory under `skills/` with
 operational reference material: script options, configuration templates, file

--- a/docs/l402-api-examples.md
+++ b/docs/l402-api-examples.md
@@ -1,0 +1,76 @@
+# Real-World L402 API Examples
+
+These are live L402 APIs you can use with `lnget` to test Lightning payments. All endpoints return a `402 Payment Required` response with an embedded Lightning invoice — exactly how L402 is designed to work.
+
+## Quick Start Examples
+
+### Get Bitcoin fee estimates (50 sats)
+```bash
+lnget --max-cost 50 -X POST \
+  -d '{"action":"l402_onchain_fee"}' \
+  https://lightningfaucet.com/api/
+```
+
+### Get BTC price data (200 sats)
+```bash
+lnget --max-cost 200 -X POST \
+  -d '{"action":"l402_price_oracle"}' \
+  https://lightningfaucet.com/api/
+```
+
+### AI text completion via GPT-4o-mini (100 sats)
+```bash
+lnget --max-cost 100 -X POST \
+  -d '{"action":"l402_llm_prompt","prompt":"Explain the Lightning Network in one sentence"}' \
+  https://lightningfaucet.com/api/
+```
+
+### Get a Bitcoin fortune cookie (10 sats)
+```bash
+lnget --max-cost 10 -X POST \
+  -d '{"action":"l402_fortune"}' \
+  https://lightningfaucet.com/api/
+```
+
+### High-precision time + Bitcoin block height (10 sats)
+```bash
+lnget --max-cost 10 -X POST \
+  -d '{"action":"l402_time"}' \
+  https://lightningfaucet.com/api/
+```
+
+### Sentiment analysis (30 sats)
+```bash
+lnget --max-cost 30 -X POST \
+  -d '{"action":"l402_sentiment","text":"Bitcoin is the future of money"}' \
+  https://lightningfaucet.com/api/
+```
+
+## Multi-Provider Examples
+
+The L402 ecosystem includes multiple providers. Here are examples from the [LightningFaucet L402 Registry](https://lightningfaucet.com/l402-registry):
+
+### AI text generation via Maximum Sats (21 sats)
+```bash
+lnget --max-cost 21 -X POST \
+  https://maximumsats.com/dvm
+```
+
+### Nostr Web of Trust score (1 sat)
+```bash
+lnget --max-cost 1 \
+  "https://wot.klabo.world/score?pubkey=<hex_pubkey>"
+```
+
+### Bitcoin blockchain timestamping via CertVera (25,000 sats)
+```bash
+lnget --max-cost 25000 -X POST \
+  -d '{"hash":"<sha256_hash>"}' \
+  https://certvera.com/api/l402
+```
+
+## Discover More L402 APIs
+
+Browse the full L402 API Registry at [lightningfaucet.com/l402-registry](https://lightningfaucet.com/l402-registry) — the only curated directory of L402-enabled APIs, with 4 providers, 36 endpoints across 5 categories.
+
+API providers can submit new L402 endpoints for listing (1,000 sats listing fee, 24-hour review).


### PR DESCRIPTION
Adds real-world L402 API examples to replace the placeholder `api.example.com` endpoints. These are live, production L402 APIs from [LightningFaucet.com](https://lightningfaucet.com), which operates the only curated L402 API registry (4 providers, 36 endpoints, 5 categories).

This gives developers and AI agents actual endpoints to test against when learning `lnget` and the L402 protocol.

## Changes

- **`docs/l402-api-examples.md`** (new) — 9 real `lnget` examples across multiple L402 providers: Bitcoin fee estimates, price oracles, AI completions, fortune cookies, time data, sentiment analysis, Nostr web-of-trust scores, and Bitcoin blockchain timestamping
- **`README.md`** — adds L402 API Examples to the Documentation table and a new L402 API Directory subsection linking to [lightningfaucet.com/l402-registry](https://lightningfaucet.com/l402-registry)

## Why

The existing `lnget` docs use `api.example.com` placeholders. Developers and agents trying to learn L402 have no real endpoint to test against. These examples are:
- Live and working (as of April 2026)
- Low cost (1–200 sats per call)
- Diverse (Bitcoin data, AI, content, utilities)
- Multi-provider (showing the L402 ecosystem, not just one vendor)

## Testing

All endpoints can be tested directly:

```bash
# Cheapest example — 1 sat
lnget --max-cost 1 "https://wot.klabo.world/score?pubkey=<hex_pubkey>"

# Quick LightningFaucet demo — 10 sats
lnget --max-cost 10 -X POST -d '{"action":"l402_fortune"}' https://lightningfaucet.com/api/
```