### PR TITLE
Add run-litd skill: native Ubuntu setup for litd and LND

### DIFF
--- a/skills/run-litd/SKILL.md
+++ b/skills/run-litd/SKILL.md
@@ -1,0 +1,390 @@
+---
+name: run-litd
+description: "Setting up a Bitcoin Lightning node on Ubuntu using litd (Lightning Terminal). Default path: Neutrino-backed single node (fast, no bitcoind needed). Also covers bitcoind-backed routing nodes and the remote signer architecture for production."
+---
+
+# Run litd — Node Setup & Remote Signer
+
+Reference for setting up litd (Lightning Terminal) and LND on Ubuntu, including the recommended remote signer architecture that separates key-holding from routing.
+
+Tested on Ubuntu 24.04 LTS. Current target versions: **bitcoind v31.0**, **litd v0.16.1-alpha**, **LND v0.20.1-beta**.
+
+Source scripts: https://github.com/HannahMR/run-litd
+
+---
+
+## Architecture Overview
+
+| Role | Software | Holds keys? | Internet-exposed? |
+|------|----------|-------------|-------------------|
+| **Single node** | litd (integrated) | Yes | Yes |
+| **Signer node** | LND (standalone) | Yes — wallet + private keys | No — ideally on private network |
+| **Routing node** | litd (watch-only) | No | Yes — public Lightning node |
+
+The remote signer architecture is recommended for production: the signer holds keys and is never internet-exposed; the routing node handles payments. Three files transfer from signer to routing node: `tls.cert` (rename to `signer-tls.cert`), `signer.macaroon`, `accounts.json`.
+
+---
+
+## Node Setup Options
+
+| | Neutrino (default) | bitcoind |
+|---|---|---|
+| **Bitcoin backend** | Lightweight SPV, built into LND | Full node |
+| **Disk required** | ~1 GB | 80 GB+ pruned / 800 GB+ full |
+| **Sync time** | Minutes | Hours–days |
+| **Mainnet routing** | Not recommended | ✓ |
+| **Signet / dev** | ✓ Ideal | ✓ |
+
+**Default behaviour:** unless the user explicitly asks for bitcoind or a source build, always use the Neutrino binary path.
+
+---
+
+## Server Requirements
+
+- Ubuntu 24.04 LTS (also tested on 22.04)
+- 2+ CPU cores, 4 GB+ RAM
+- Storage: ~10 GB for Neutrino; 80 GB+ for pruned bitcoind node; 800 GB+ for full mainnet node
+- For attached-disk full nodes, set `datadir=/path/to/disk` in `bitcoin.conf`
+
+---
+
+## Before You Begin
+
+### Step 1 — Check sudo access
+
+The setup scripts require root to install binaries to `/usr/local/bin/`, install packages via `apt-get`, write systemd service files to `/etc/systemd/system/`, and run `systemctl` commands. Check that passwordless sudo is working before doing anything else:
+
+```bash
+sudo -n true 2>/dev/null && echo "OK" || echo "NEEDS_SETUP"
+```
+
+If the output is `NEEDS_SETUP`, explain to the user why these permissions are needed — the setup scripts must install binaries to `/usr/local/bin/`, install packages via `apt-get`, write systemd service files to `/etc/systemd/system/`, and run `systemctl` commands, all of which require root. Claude cannot enter a password interactively, so passwordless sudo must be configured first. Then ask them to run the fix:
+
+> "I need you to open a new SSH terminal tab and paste these two commands, then let me know when done. This is a one-time setup for this server. Note that each command pipes through `sudo tee` — the `sudo` is required to write to `/etc/sudoers.d/`, so you will be prompted for your password. Do not remove `sudo` from the commands."
+>
+> ```bash
+> echo 'Defaults:ubuntu !use_pty' | sudo tee /etc/sudoers.d/ubuntu-nopty > /dev/null
+> sudo chmod 0440 /etc/sudoers.d/ubuntu-nopty
+> ```
+> ```bash
+> echo 'ubuntu ALL=(ALL) NOPASSWD: ALL' | sudo tee /etc/sudoers.d/ubuntu-nopasswd > /dev/null
+> sudo chmod 0440 /etc/sudoers.d/ubuntu-nopasswd
+> ```
+
+Wait for the user to confirm, then re-run `sudo -n true` to verify before continuing.
+
+### Step 2 — Gather setup details
+
+Ask the user:
+1. Which network — **signet** (testing) or **mainnet** (production)?
+2. Which role is this machine — **single node**, **signer node**, or **routing node**?
+
+**Default behaviour:** use the Neutrino binary path unless the user explicitly asks for bitcoind or a source build. Neutrino is built into LND — no separate Bitcoin node or service needed. It is ideal for signet and development but not recommended for mainnet production routing nodes due to peer dependency.
+
+Once you have the answers, run `sudo -v` to cache credentials, then jump to the relevant section below.
+
+---
+
+## Neutrino Setup (Default)
+
+Neutrino is a lightweight SPV Bitcoin client built into LND — no bitcoind installation required. litd still needs its own `lit.conf` and systemd service; `neutrino_setup3.sh` handles both.
+
+**Important:** the setup scripts use interactive `read` prompts that Claude CLI cannot respond to. Generate the config files directly before running the scripts — each script checks for existing files and skips the interactive config section automatically.
+
+### Single node (litd + Neutrino)
+
+This path installs litd with a Neutrino backend. litd provides the web UI and integrated LND node.
+
+**Before running the script**, ask the user for:
+- A UI password (for the litd web interface)
+- A node alias
+
+Then generate the config files using the Bash tool. Read `${CLAUDE_SKILL_DIR}/neutrino/neutrino_setup_binary.sh` to see the exact config structure the script would produce, then reproduce it with the user's values substituted in:
+
+```bash
+mkdir -p ~/.lnd ~/.lit
+openssl rand -hex 21 > ~/.lnd/wallet_password
+chmod 600 ~/.lnd/wallet_password
+# Write ~/.lit/lit.conf via heredoc — structure is in neutrino_setup_binary.sh
+```
+
+Once the config files exist, run the install script — it installs litd and skips the interactive config section:
+
+```bash
+chmod +x ${CLAUDE_SKILL_DIR}/neutrino/neutrino_setup_binary.sh ${CLAUDE_SKILL_DIR}/neutrino/neutrino_setup3.sh
+sudo ${CLAUDE_SKILL_DIR}/neutrino/neutrino_setup_binary.sh
+```
+
+After the install script completes, create the wallet automatically:
+
+```bash
+chmod +x ${CLAUDE_SKILL_DIR}/litd_wallet_create.sh
+sudo ${CLAUDE_SKILL_DIR}/litd_wallet_create.sh
+```
+
+This starts litd in the background, creates the wallet via the LND REST API, saves the seed to `~/.lnd/seed_phrase.txt`, and stops litd. Prompt the user to back up and delete the seed:
+
+> "Your seed phrase has been saved to `~/.lnd/seed_phrase.txt`. Back it up to offline storage now — it is your only recovery option. Then delete it: `shred -u ~/.lnd/seed_phrase.txt`"
+
+Wait for confirmation, then enable auto-unlock and the systemd service:
+
+```bash
+sudo ${CLAUDE_SKILL_DIR}/neutrino/neutrino_setup3.sh
+```
+
+---
+
+### Neutrino remote signer (signer node only)
+
+This path installs LND only (no litd, no web UI) and uses Neutrino as the Bitcoin backend. The routing node runs litd with bitcoind separately.
+
+**Before running the script**, ask the user for:
+- The IP address of this signer machine (the routing node connects to it over gRPC)
+- A node alias
+
+Then generate the config files using the Bash tool. Read `${CLAUDE_SKILL_DIR}/neutrino/remote-signer-neutrino-binary.sh` to see the exact config structure the script would produce, then reproduce it with the user's values substituted in:
+
+```bash
+mkdir -p ~/.lnd
+openssl rand -hex 21 > ~/.lnd/wallet_password
+chmod 600 ~/.lnd/wallet_password
+# Write ~/.lnd/lnd.conf via heredoc — structure is in remote-signer-neutrino-binary.sh
+```
+
+Once the config files exist, run the script:
+
+```bash
+chmod +x ${CLAUDE_SKILL_DIR}/neutrino/remote-signer-neutrino-binary.sh
+sudo ${CLAUDE_SKILL_DIR}/neutrino/remote-signer-neutrino-binary.sh
+```
+
+The script installs LND, skips config generation (files already exist), creates the `lnd` systemd service, and **automatically creates and initialises the wallet via REST** — no manual `lncli create` step needed.
+
+When the script completes, prompt the user to back up the seed:
+
+> "Your seed phrase has been saved to `~/.lnd/seed_phrase.txt`. Back it up to offline storage now — it is your only recovery option. Then delete it: `shred -u ~/.lnd/seed_phrase.txt`"
+
+Then follow Step 2 — Transfer Files and Step 3 — Routing Node from the Remote Signer Setup section below.
+
+---
+
+## Bitcoind + litd Setup (explicit request only)
+
+Use this path when the user has specifically asked for a bitcoind-backed node. Run bitcoind first, then litd.
+
+### Step 1 — bitcoind
+
+The bitcoind script generates its own RPC password via `rpcauth.py` — Claude cannot pre-generate it. Before running, tell the user:
+
+> "The bitcoind setup script will display an RPC password. Please copy it and paste it back to me when prompted — I'll use it to configure litd. The script will also ask which network you want (signet or mainnet)."
+
+```bash
+sudo ${CLAUDE_SKILL_DIR}/bitcoind_setup_binary.sh
+# Source build alternative: sudo ${CLAUDE_SKILL_DIR}/bitcoind_setup.sh
+```
+
+After the script completes, ask the user: "What RPC password did the script display?" Then store it — you will use it in the next step. Verify bitcoind is running before continuing:
+
+```bash
+bitcoin-cli -signet getblockchaininfo   # signet
+bitcoin-cli getblockchaininfo           # mainnet
+```
+
+### Step 2 — litd
+
+**Before running the script**, ask the user for:
+- UI password (for the litd web interface)
+- Node alias
+
+Then pre-generate the config files. Read `${CLAUDE_SKILL_DIR}/litd_setup_binary.sh` to see the exact config structure, then reproduce it using the network from Before You Begin Step 2, the RPC password from Step 1 above, and the UI password and alias just collected:
+
+```bash
+mkdir -p ~/.lnd ~/.lit
+openssl rand -hex 21 > ~/.lnd/wallet_password
+chmod 600 ~/.lnd/wallet_password
+# Write ~/.lit/lit.conf via heredoc — structure is in litd_setup_binary.sh
+```
+
+Once config files exist, run the install script — it installs litd and skips the interactive config section:
+
+```bash
+sudo ${CLAUDE_SKILL_DIR}/litd_setup_binary.sh
+```
+
+After the install script completes, create the wallet automatically:
+
+```bash
+chmod +x ${CLAUDE_SKILL_DIR}/litd_wallet_create.sh
+sudo ${CLAUDE_SKILL_DIR}/litd_wallet_create.sh
+```
+
+This starts litd in the background, creates the wallet via the LND REST API, saves the seed to `~/.lnd/seed_phrase.txt`, and stops litd. Prompt the user to back up and delete the seed:
+
+> "Your seed phrase has been saved to `~/.lnd/seed_phrase.txt`. Back it up to offline storage now — it is your only recovery option. Then delete it: `shred -u ~/.lnd/seed_phrase.txt`"
+
+Wait for confirmation, then enable auto-unlock and the systemd service:
+
+```bash
+sudo ${CLAUDE_SKILL_DIR}/litd_setup3.sh
+```
+
+**Source build:** `litd_setup.sh` (installs Go/Node/Yarn) → new shell → `litd_setup2.sh` (builds litd) → `source ~/.profile` if `litd`/`lncli` are not found → create wallet as above → `litd_setup3.sh`.
+
+---
+
+## Remote Signer Setup
+
+### Step 1 — Signer Node
+
+Two options depending on whether bitcoind is available on the signer machine:
+
+**Neutrino signer (default — no bitcoind needed):**
+
+Follow the pre-generation steps in the **Neutrino remote signer** section above — collect signer IP and node alias, generate `wallet_password` and `lnd.conf`, then run:
+
+```bash
+chmod +x ${CLAUDE_SKILL_DIR}/neutrino/remote-signer-neutrino-binary.sh
+sudo ${CLAUDE_SKILL_DIR}/neutrino/remote-signer-neutrino-binary.sh
+```
+
+**bitcoind signer (explicit request only — bitcoind must already be installed and running):**
+```bash
+chmod +x ${CLAUDE_SKILL_DIR}/remote-signer/remote-signer-binary.sh
+sudo ${CLAUDE_SKILL_DIR}/remote-signer/remote-signer-binary.sh
+```
+
+The script:
+1. Installs LND v0.20.1-beta (GPG + SHA256 verified)
+2. Creates `~/.lnd/` and generates `wallet_password`
+3. Configures `lnd.conf` for signing role (no p2p, `nolisten=true`, gRPC on `0.0.0.0:10009`, `tlsextraip=<signer-ip>`)
+4. Creates and starts `lnd.service` via systemd
+5. Generates the wallet seed via REST (`/v1/genseed`), initialises the wallet, saves seed to `~/.lnd/seed_phrase.txt`
+6. Exports xpubs: `lncli wallet accounts list > ~/.lnd/accounts.json`
+7. Bakes a minimum-permission signing macaroon: `~/.lnd/signer.macaroon`
+
+**Immediately after the script completes**, back up the seed:
+
+```bash
+cat ~/.lnd/seed_phrase.txt
+shred -u ~/.lnd/seed_phrase.txt
+```
+
+---
+
+### Step 2 — Transfer Files to Routing Node
+
+Copy three files from the signer to the routing node. The signer's TLS cert **must** be renamed to avoid collision with litd's own cert.
+
+```bash
+# Run from routing node (or adjust source/destination)
+scp ubuntu@<signer-ip>:~/.lnd/tls.cert        ~/.lnd/signer-tls.cert
+scp ubuntu@<signer-ip>:~/.lnd/signer.macaroon ~/.lnd/signer.macaroon
+scp ubuntu@<signer-ip>:~/.lnd/accounts.json   ~/.lnd/accounts.json
+```
+
+Verify all three files are present before running the routing node script:
+```bash
+ls -la ~/.lnd/signer-tls.cert ~/.lnd/signer.macaroon ~/.lnd/accounts.json
+```
+
+---
+
+### Step 3 — Routing Node
+
+Run on the routing node machine. Bitcoind must already be installed and running. All three signer files must be in `~/.lnd/` before running.
+
+**Before running the script**, the routing node script also has interactive prompts. Pre-generate the config using the same pattern as the bitcoind + litd section:
+
+1. If bitcoind was just set up on this machine, ask the user for the RPC password it generated. If bitcoind was already running, ask the user for the existing RPC password.
+2. Ask the user for: UI password, node alias. (Network is from Before You Begin Step 2; signer IP is from Step 1.)
+3. Generate config files. Read `${CLAUDE_SKILL_DIR}/remote-signer/routing-node-binary.sh` for the exact `lit.conf` structure — it includes `lnd.remotesigner.*` settings pointing at the signer IP from Step 1:
+
+```bash
+mkdir -p ~/.lnd ~/.lit
+openssl rand -hex 21 > ~/.lnd/wallet_password
+chmod 600 ~/.lnd/wallet_password
+# Write ~/.lit/lit.conf via heredoc — structure is in routing-node-binary.sh
+```
+
+**Binary install:**
+```bash
+chmod +x ${CLAUDE_SKILL_DIR}/remote-signer/routing-node-binary.sh ${CLAUDE_SKILL_DIR}/remote-signer/routing-node3.sh
+sudo ${CLAUDE_SKILL_DIR}/remote-signer/routing-node-binary.sh
+```
+
+The script:
+1. Installs litd v0.16.1-alpha (GPG + SHA256 verified)
+2. Checks for the three signer files — exits with `scp` instructions if any are missing
+3. Generates `~/.lit/lit.conf` with `remotesigner.*` settings pointing at the signer
+4. Pauses — you must create the watch-only wallet before continuing
+
+**Create the watch-only wallet (manual step between scripts):**
+```bash
+# Start litd without systemd for first-time wallet setup
+litd
+
+# In a new terminal — initialise watch-only wallet from signer's xpubs
+lncli --network=signet createwatchonly ~/.lnd/accounts.json
+# Use the password from ~/.lnd/wallet_password
+
+# Stop litd (Ctrl-C)
+```
+
+**Enable auto-unlock and systemd service:**
+```bash
+sudo ${CLAUDE_SKILL_DIR}/remote-signer/routing-node3.sh
+```
+
+`routing-node3.sh` uncomments the wallet unlock lines in `lit.conf` and creates `litd.service`.
+
+**Source build:** `routing-node.sh` (installs Go/Node/Yarn) → new shell → `routing-node2.sh` (builds litd) → `source ~/.profile` if `litd`/`lncli` are not found → create watch-only wallet as above → `routing-node3.sh`.
+
+---
+
+## Verification Commands
+
+```bash
+# Node info (shows synced_to_chain, synced_to_graph, pubkey)
+lncli --network=signet getinfo
+
+# Check wallet balance
+lncli --network=signet walletbalance
+
+# List peers
+lncli --network=signet listpeers
+
+# Connect to a peer (required before synced_to_graph=true)
+lncli --network=signet connect <pubkey>@<host>:<port>
+
+# Check service status
+systemctl status litd
+systemctl status lnd        # signer node only
+systemctl status bitcoind
+
+# Tail logs
+journalctl -fu litd
+journalctl -fu lnd
+
+# Verify signer connectivity from routing node
+lncli --network=signet --macaroonpath=~/.lnd/signer.macaroon \
+  --tlscertpath=~/.lnd/signer-tls.cert \
+  --rpcserver=<signer-ip>:10009 \
+  getinfo
+```
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Fix |
+|---------|-----|
+| `synced_to_graph: false` on routing node | Connect to at least one peer: `lncli connect <pubkey>@<host>:<port>` |
+| Script exits "Missing required signer file" | Run `scp` to copy all three files from signer — see Step 2 above. Don't forget to rename `tls.cert` → `signer-tls.cert`. |
+| `tls.cert` and `signer-tls.cert` confusion | The routing node generates its own `~/.lit/tls.cert`. The signer's cert must live at `~/.lnd/signer-tls.cert`. `lit.conf` must point `remotesigner.tlscertpath` to the signer cert, not the local one. |
+| Watch-only wallet creation fails | `createwatchonly` must be run while litd is running but *before* auto-unlock lines are uncommented in `lit.conf`. Run `routing-node3.sh` only after the wallet exists. |
+| `wallet-unlock-allow-create=true` causes issues | This flag is intentionally commented out in the initial config. `routing-node3.sh` uncomments it. Do not uncomment manually before the watch-only wallet is created. |
+| Signer not reachable from routing node | Check that port 10009 is open between the two machines. The signer's `lnd.conf` must have `tlsextraip=<signer-ip>` set before the wallet was initialised (TLS cert bakes the IP in). If the IP was wrong, delete `~/.lnd/tls.cert` and `~/.lnd/tls.key` and restart lnd to regenerate. |
+| Scripts fail on re-run after interruption | All scripts check existing state and skip completed steps — safe to re-run. |
+| Seed phrase not backed up | The remote signer scripts and `litd_wallet_create.sh` all save the seed to `~/.lnd/seed_phrase.txt`. Back it up to offline storage and then `shred -u ~/.lnd/seed_phrase.txt` immediately. |
+| `lncli` uses wrong macaroon/network | Always pass `--network=<mainnet|signet>` and confirm `--macaroonpath` points to the correct node's macaroon. Omitting `--network` defaults to mainnet. |
+| litd binary not found in PATH after install | Binary installs go to `/usr/local/bin` — check it is in `$PATH`. Source builds install to `~/go/bin` — run `source ~/.profile` or start a new shell after `litd_setup2.sh` or `routing-node2.sh` if `litd` or `lncli` are not found. |

--- a/skills/run-litd/bitcoind_setup.sh
+++ b/skills/run-litd/bitcoind_setup.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+
+# Bitcoin Core Node Setup Script
+# Tested on Ubuntu 24.04
+
+set -e
+
+# Configuration
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+BITCOIN_VERSION="31.0" 
+BITCOIN_DIR="$USER_HOME/.bitcoin"
+BITCOIN_CONF="$BITCOIN_DIR/bitcoin.conf"
+RPC_AUTH=""
+NETWORK=""
+SERVICE_FILE="/etc/systemd/system/bitcoind.service"
+
+# Check if user is root
+echo "[+] Checking for root privileges..."
+if [[ $EUID -ne 0 ]]; then
+  echo "[-] This script must be run as root. Use sudo."
+  exit 1
+fi
+
+# Update & Install dependencies
+echo "[+] Updating system and installing dependencies..."
+apt update && apt upgrade -y
+apt install -y git build-essential cmake ninja-build \
+  libtool autotools-dev automake pkg-config libcapnp-dev capnproto \
+  libssl-dev libevent-dev libzmq3-dev libminiupnpc-dev \
+  libboost-system-dev libboost-filesystem-dev libboost-chrono-dev \
+  libboost-program-options-dev libboost-test-dev libboost-thread-dev \
+  python3
+
+# Clone Bitcoin Core repository
+echo "[+] Checking for Bitcoin Core repository..."
+if [[ ! -d "$USER_HOME/bitcoin" ]]; then
+    echo "[+] Cloning Bitcoin Core repository using v$BITCOIN_VERSION into $USER_HOME..."
+    git clone -b v$BITCOIN_VERSION https://github.com/bitcoin/bitcoin.git "$USER_HOME/bitcoin"
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/bitcoin"
+else
+    echo "[!] Bitcoin repository already exists. Skipping clone."
+fi
+
+# Navigate to the repository
+cd "$USER_HOME/bitcoin/"
+
+# Build Bitcoin Core from source
+if [[ ! -f "/usr/local/bin/bitcoind" ]]; then
+    echo "[+] Building Bitcoin Core. This may take a while..."
+    if [[ -f "./autogen.sh" ]]; then
+  # Old releases (<= v28.*)
+  ./autogen.sh
+  ./configure --with-zmq --without-gui --disable-wallet --disable-tests --disable-bench --enable-upnp-default
+  make -j"$(nproc)"
+  sudo make install
+else
+  # New releases (v29+ use CMake)
+  rm -rf build
+  mkdir -p build && cd build
+  cmake -G Ninja .. \
+  -DBUILD_GUI=OFF \
+  -DENABLE_WALLET=OFF \
+  -DWITH_ZMQ=ON \
+  -DBUILD_TESTS=OFF \
+  -DBUILD_BENCH=OFF
+
+  cmake --build . -j"$(nproc)"
+  sudo cmake --install .
+  cd ..
+fi
+
+else
+    echo "[!] bitcoind is already installed. Skipping build."
+fi
+
+# Head back to the user home directory
+cd "$USER_HOME"
+
+# Generate RPC password
+echo "[+] Generating RPC password for other services to connect to bitcoind..."
+wget -q "https://raw.githubusercontent.com/bitcoin/bitcoin/v${BITCOIN_VERSION}/share/rpcauth/rpcauth.py" -O rpcauth.py
+if [[ ! -f rpcauth.py ]]; then
+    echo "[-] Failed to download RPC password generator. Exiting."
+    exit 1
+fi
+
+# Run the RPC auth script
+RPC_OUTPUT=$(python3 ./rpcauth.py bitcoinrpc)
+RPC_AUTH=$(echo "$RPC_OUTPUT" | grep -oP '(?<=rpcauth=)\S+')
+RPC_PASSWORD=$(echo "$RPC_OUTPUT" | awk '/Your password:/ {getline; print $1}' | tr -d '[:space:]')
+
+# Display the password to the user
+echo "[+] The following password has been generated for your RPC connection:"
+echo "    Password: $RPC_PASSWORD"
+echo "[!] Please save this password securely, as it will not be displayed again."
+
+# Confirm user saved the password
+read -p "Have you saved the password? (yes/no): " CONFIRM
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "[-] Please save the password before continuing. Exiting setup."
+    exit 1
+fi
+
+# Ask user to choose network
+while true; do
+    read -p "Do you want to run on mainnet or signet? (mainnet/signet): " NETWORK
+    if [[ "$NETWORK" == "mainnet" || "$NETWORK" == "signet" ]]; then
+        break
+    else
+        echo "[-] Invalid input. Please enter 'mainnet' or 'signet'."
+    fi
+done
+
+# Create bitcoin.conf file
+if [[ -f "$BITCOIN_CONF" ]]; then
+    read -p "[!] bitcoin.conf already exists. Overwrite? (yes/no): " OVERWRITE
+    if [[ "$OVERWRITE" != "yes" ]]; then
+        echo "[!] Skipping bitcoin.conf creation."
+    else
+        echo "[+] Overwriting bitcoin.conf..."
+    fi
+fi
+
+mkdir -p $BITCOIN_DIR
+sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $BITCOIN_DIR
+cat <<EOF > $BITCOIN_CONF
+# Set the best block hash here:
+# For v31.0 on Signet a good hash to try is...
+# 00000008414aab61092ef93f1aacc54cf9e9f16af29ddad493b908a01ff5c329
+#assumevalid=
+
+# Run as a daemon mode without an interactive shell
+daemon=1
+
+# Set the number of megabytes of RAM to use, set to like 50% of available memory
+dbcache=3000
+
+# Add visibility into mempool and RPC calls for potential LND debugging
+debug=mempool
+debug=rpc
+
+# Turn off the wallet, it won't be used
+disablewallet=1
+
+# Don't bother listening for peers
+listen=0
+
+# Constrain the mempool to the number of megabytes needed:
+maxmempool=100
+
+# Limit uploading to peers
+maxuploadtarget=1000
+
+# Turn off serving SPV nodes
+nopeerbloomfilters=1
+peerbloomfilters=0
+
+# Don't accept deprecated multi-sig style
+permitbaremultisig=0
+
+# Set the RPC auth to what was set above
+rpcauth=$RPC_AUTH
+
+# Turn on the RPC server
+server=1
+
+# Reduce the log file size on restarts
+shrinkdebuglog=1
+
+# Set signet if needed
+$( [[ "$NETWORK" == "signet" ]] && echo "signet=1" || echo "#signet=1" )
+
+# Prune the blockchain. Example prune to 50GB
+prune=50000
+
+# Turn on transaction lookup index, if pruned node is off. 
+txindex=0
+
+# Turn on ZMQ publishing
+zmqpubrawblock=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:28333
+EOF
+
+# Set ownership of the configuration file to the user
+sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $BITCOIN_CONF
+
+# Inform user where the configuration file is located
+echo "[+] Your bitcoin.conf file has been created at: $BITCOIN_CONF"
+
+# Create systemd service file
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    echo "[+] Creating systemd service file for bitcoind..."
+    cat <<EOF > $SERVICE_FILE
+[Unit]
+Description=Bitcoin daemon
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/bitcoind
+Type=forking
+Restart=on-failure
+
+User=${SUDO_USER:-$USER}
+Group=sudo
+
+[Install]
+WantedBy=multi-user.target
+EOF
+else
+    echo "[!] Systemd service file already exists. Skipping creation."
+fi
+
+# Enable, reload, and start systemd service
+systemctl enable bitcoind
+systemctl daemon-reload
+if ! systemctl is-active --quiet bitcoind; then
+    systemctl start bitcoind
+    echo "[+] bitcoind service started."
+else
+    echo "[!] bitcoind service is already running."
+fi
+
+# Done
+cat <<"EOF"
+
+[+] Bitcoin Core built, configured, and service enabled successfully!
+
+    ⠀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣴⣶⣾⣿⣿⣿⣿⣷⣶⣦⣤⣀⠀⠀⠀⠀⠀⠀⠀⠀
+    ⠀⠀⠀⠀⠀⣠⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⣄⠀⠀⠀⠀⠀
+    ⠀⠀⠀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣄⠀⠀⠀
+    ⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠟⠿⠿⡿⠀⢰⣿⠁⢈⣿⣿⣿⣿⣿⣿⣿⣿⣦⠀⠀
+    ⠀⣼⣿⣿⣿⣿⣿⣿⣿⣿⣤⣄⠀⠀⠀⠈⠉⠀⠸⠿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀
+    ⢰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡏⠀⠀⢠⣶⣶⣤⡀⠀⠈⢻⣿⣿⣿⣿⣿⣿⣿⡆
+    ⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⠀⠀⠼⣿⣿⡿⠃⠀⠀⢸⣿⣿⣿⣿⣿⣿⣿⣷
+    ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⠀⠀⢀⣀⣀⠀⠀⠀⠀⢴⣿⣿⣿⣿⣿⣿⣿⣿⣿
+    ⢿⣿⣿⣿⣿⣿⣿⣿⢿⣿⠁⠀⠀⣼⣿⣿⣿⣦⠀⠀⠈⢻⣿⣿⣿⣿⣿⣿⣿⡿
+    ⠸⣿⣿⣿⣿⣿⣿⣏⠀⠀⠀⠀⠀⠛⠛⠿⠟⠋⠀⠀⠀⣾⣿⣿⣿⣿⣿⣿⣿⠇
+    ⠀⢻⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⣤⡄⠀⣀⣀⣀⣀⣠⣾⣿⣿⣿⣿⣿⣿⣿⡟⠀
+    ⠀⠀⠻⣿⣿⣿⣿⣿⣿⣿⣄⣰⣿⠁⢀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠀⠀
+    ⠀⠀⠀⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠋⠀⠀⠀
+    ⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠋⠀⠀⠀⠀⠀
+⠀    ⠀⠀⠀⠀⠀⠀⠀⠉⠛⠻⠿⢿⣿⣿⣿⣿⡿⠿⠟⠛⠉⠀⠀⠀⠀⠀⠀⠀⠀
+
+[+] Your Bitcoin node is now up and running!
+EOF

--- a/skills/run-litd/bitcoind_setup_binary.sh
+++ b/skills/run-litd/bitcoind_setup_binary.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+
+# Bitcoin Core Node Setup Script
+# Tested on Ubuntu 24.04
+
+set -e
+
+# Configuration
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+BITCOIN_DIR="$USER_HOME/.bitcoin"
+BITCOIN_CONF="$BITCOIN_DIR/bitcoin.conf"
+RPC_AUTH=""
+NETWORK=""
+SERVICE_FILE="/etc/systemd/system/bitcoind.service"
+BITCOIN_VERSION="31.0"  
+BITCOIN_TARBALL="bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz"
+BITCOIN_URL="https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/${BITCOIN_TARBALL}"
+SHA256SUMS_URL="https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS"
+SHA256SUMS_ASC_URL="https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc"
+
+# Check if user is root
+echo "[+] Checking for root privileges..."
+if [[ $EUID -ne 0 ]]; then
+  echo "[-] This script must be run as root. Use sudo."
+  exit 1
+fi
+
+# Update & Install dependencies
+echo "[+] Updating system and installing dependencies..."
+apt update && apt upgrade -y
+apt install -y wget tar gnupg
+
+# Download Bitcoin Core binary and related files
+echo "[+] Downloading Bitcoin Core binary, checksums, and signatures..."
+wget -q $BITCOIN_URL -O $BITCOIN_TARBALL
+wget -q $SHA256SUMS_URL -O SHA256SUMS
+wget -q $SHA256SUMS_ASC_URL -O SHA256SUMS.asc
+
+if [[ ! -f $BITCOIN_TARBALL || ! -f SHA256SUMS || ! -f SHA256SUMS.asc ]]; then
+    echo "[-] Failed to download necessary files. Exiting."
+    exit 1
+fi
+
+# Verify SHA256 checksum
+echo "[+] Verifying SHA256 checksum of the binary..."
+sha256sum --ignore-missing --check SHA256SUMS
+if [[ $? -ne 0 ]]; then
+    echo "[-] SHA256 checksum verification failed. Exiting."
+    exit 1
+fi
+echo "[+] SHA256 checksum verified successfully."
+
+# Import Bitcoin Core signing keys
+echo "[+] Checking for 'guix.sigs' directory..."
+if [[ -d "guix.sigs" ]]; then
+    echo "[!] 'guix.sigs' directory already exists. Pulling the latest changes..."
+    cd guix.sigs
+    git pull --ff-only || { echo "[-] Failed to update 'guix.sigs'. Please resolve manually."; exit 1; }
+    cd ..
+else
+    echo "[+] Cloning 'guix.sigs' repository..."
+    git clone https://github.com/bitcoin-core/guix.sigs guix.sigs || { echo "[-] Failed to clone 'guix.sigs'. Exiting."; exit 1; }
+fi
+
+echo "[+] Importing Bitcoin Core signing keys..."
+gpg --import guix.sigs/builder-keys/* || { echo "[-] Failed to import Bitcoin Core signing keys. Exiting."; exit 1; }
+
+# Verify PGP signature of the SHA256SUMS file
+echo "[+] Verifying PGP signature of the SHA256SUMS file..."
+gpg --verify SHA256SUMS.asc SHA256SUMS
+if [[ $? -ne 0 ]]; then
+    echo "[-] PGP signature verification failed. Exiting."
+    exit 1
+fi
+echo "[+] PGP signature verified successfully."
+
+# Extract and install Bitcoin Core binary
+echo "[+] Extracting Bitcoin Core binary..."
+tar -xzf $BITCOIN_TARBALL
+BITCOIN_EXTRACT_DIR="bitcoin-${BITCOIN_VERSION}"
+
+if [[ -d "$BITCOIN_EXTRACT_DIR/bin" ]]; then
+    sudo install -m 0755 -o root -g root -t /usr/local/bin $BITCOIN_EXTRACT_DIR/bin/*
+    rm -rf $BITCOIN_TARBALL $BITCOIN_EXTRACT_DIR
+    echo "[+] Bitcoin Core binaries installed successfully."
+else
+    echo "[-] Expected directory structure not found: $BITCOIN_EXTRACT_DIR/bin. Exiting."
+    rm -rf $BITCOIN_TARBALL $BITCOIN_EXTRACT_DIR
+    exit 1
+fi
+
+# Head back to the user home directory
+cd "$USER_HOME"
+
+# Generate RPC password
+echo "[+] Generating RPC password for other services to connect to bitcoind..."
+wget -q "https://raw.githubusercontent.com/bitcoin/bitcoin/v${BITCOIN_VERSION}/share/rpcauth/rpcauth.py" -O rpcauth.py
+if [[ ! -f rpcauth.py ]]; then
+    echo "[-] Failed to download RPC password generator. Exiting."
+    exit 1
+fi
+
+# Run the RPC auth script
+RPC_OUTPUT=$(python3 ./rpcauth.py bitcoinrpc)
+RPC_AUTH=$(echo "$RPC_OUTPUT" | grep -oP '(?<=rpcauth=)\S+')
+RPC_PASSWORD=$(echo "$RPC_OUTPUT" | awk '/Your password:/ {getline; print $1}' | tr -d '[:space:]')
+
+# Display the password to the user
+echo "[+] The following password has been generated for your RPC connection:"
+echo "    Password: $RPC_PASSWORD"
+echo "[!] Please save this password securely, as it will not be displayed again."
+
+# Confirm user saved the password
+read -p "Have you saved the password? (yes/no): " CONFIRM
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "[-] Please save the password before continuing. Exiting setup."
+    exit 1
+fi
+
+# Ask user to choose network
+while true; do
+    read -p "Do you want to run on mainnet or signet? (mainnet/signet): " NETWORK
+    if [[ "$NETWORK" == "mainnet" || "$NETWORK" == "signet" ]]; then
+        break
+    else
+        echo "[-] Invalid input. Please enter 'mainnet' or 'signet'."
+    fi
+done
+
+# Create bitcoin.conf file
+if [[ -f "$BITCOIN_CONF" ]]; then
+    read -p "[!] bitcoin.conf already exists. Overwrite? (yes/no): " OVERWRITE
+    if [[ "$OVERWRITE" != "yes" ]]; then
+        echo "[!] Skipping bitcoin.conf creation."
+    else
+        echo "[+] Overwriting bitcoin.conf..."
+    fi
+fi
+
+mkdir -p $BITCOIN_DIR
+sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $BITCOIN_DIR
+cat <<EOF > $BITCOIN_CONF
+# Set the best block hash here:
+# For v29.0 on Signet and good hash to try is... 
+# 000000432adc32a0e79b9d5cf14bd32c7d37df2b96127c963cb20c69830464f4
+#assumevalid=
+
+# Run as a daemon mode without an interactive shell
+daemon=1
+
+# Set the number of megabytes of RAM to use, set to like 50% of available memory
+dbcache=3000
+
+# Add visibility into mempool and RPC calls for potential LND debugging
+debug=mempool
+debug=rpc
+
+# Turn off the wallet, it won't be used
+disablewallet=1
+
+# Don't bother listening for peers
+listen=0
+
+# Constrain the mempool to the number of megabytes needed:
+maxmempool=100
+
+# Limit uploading to peers
+maxuploadtarget=1000
+
+# Turn off serving SPV nodes
+nopeerbloomfilters=1
+peerbloomfilters=0
+
+# Don't accept deprecated multi-sig style
+permitbaremultisig=0
+
+# Set the RPC auth to what was set above
+rpcauth=$RPC_AUTH
+
+# Turn on the RPC server
+server=1
+
+# Reduce the log file size on restarts
+shrinkdebuglog=1
+
+# Set signet if needed
+$( [[ "$NETWORK" == "signet" ]] && echo "signet=1" || echo "#signet=1" )
+
+# Prune the blockchain. Example prune to 50GB
+prune=50000
+
+# Turn on transaction lookup index, if pruned node is off. 
+txindex=0
+
+# Turn on ZMQ publishing
+zmqpubrawblock=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:28333
+EOF
+
+# Set ownership of the configuration file to the user
+sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $BITCOIN_CONF
+
+# Inform user where the configuration file is located
+echo "[+] Your bitcoin.conf file has been created at: $BITCOIN_CONF"
+
+# Create systemd service file
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    echo "[+] Creating systemd service file for bitcoind..."
+    cat <<EOF > $SERVICE_FILE
+[Unit]
+Description=Bitcoin daemon
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/bitcoind
+Type=forking
+Restart=on-failure
+
+User=${SUDO_USER:-$USER}
+Group=sudo
+
+[Install]
+WantedBy=multi-user.target
+EOF
+else
+    echo "[!] Systemd service file already exists. Skipping creation."
+fi
+
+# Enable, reload, and start systemd service
+systemctl enable bitcoind
+systemctl daemon-reload
+if ! systemctl is-active --quiet bitcoind; then
+    systemctl start bitcoind
+    echo "[+] bitcoind service started."
+else
+    echo "[!] bitcoind service is already running."
+fi
+
+# Done
+cat <<"EOF"
+
+[+] Bitcoin Core built, configured, and service enabled successfully!
+
+    ⠀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣴⣶⣾⣿⣿⣿⣿⣷⣶⣦⣤⣀⠀⠀⠀⠀⠀⠀⠀⠀
+    ⠀⠀⠀⠀⠀⣠⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⣄⠀⠀⠀⠀⠀
+    ⠀⠀⠀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣄⠀⠀⠀
+    ⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⠟⠿⠿⡿⠀⢰⣿⠁⢈⣿⣿⣿⣿⣿⣿⣿⣿⣦⠀⠀
+    ⠀⣼⣿⣿⣿⣿⣿⣿⣿⣿⣤⣄⠀⠀⠀⠈⠉⠀⠸⠿⣿⣿⣿⣿⣿⣿⣿⣿⣧⠀
+    ⢰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡏⠀⠀⢠⣶⣶⣤⡀⠀⠈⢻⣿⣿⣿⣿⣿⣿⣿⡆
+    ⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⠀⠀⠼⣿⣿⡿⠃⠀⠀⢸⣿⣿⣿⣿⣿⣿⣿⣷
+    ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⠀⠀⢀⣀⣀⠀⠀⠀⠀⢴⣿⣿⣿⣿⣿⣿⣿⣿⣿
+    ⢿⣿⣿⣿⣿⣿⣿⣿⢿⣿⠁⠀⠀⣼⣿⣿⣿⣦⠀⠀⠈⢻⣿⣿⣿⣿⣿⣿⣿⡿
+    ⠸⣿⣿⣿⣿⣿⣿⣏⠀⠀⠀⠀⠀⠛⠛⠿⠟⠋⠀⠀⠀⣾⣿⣿⣿⣿⣿⣿⣿⠇
+    ⠀⢻⣿⣿⣿⣿⣿⣿⣿⣿⠇⠀⣤⡄⠀⣀⣀⣀⣀⣠⣾⣿⣿⣿⣿⣿⣿⣿⡟⠀
+    ⠀⠀⠻⣿⣿⣿⣿⣿⣿⣿⣄⣰⣿⠁⢀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠀⠀
+    ⠀⠀⠀⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠋⠀⠀⠀
+    ⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠋⠀⠀⠀⠀⠀
+⠀    ⠀⠀⠀⠀⠀⠀⠀⠉⠛⠻⠿⢿⣿⣿⣿⣿⡿⠿⠟⠛⠉⠀⠀⠀⠀⠀⠀⠀⠀
+
+[+] Your Bitcoin node is now up and running!
+EOF

--- a/skills/run-litd/litd_setup.sh
+++ b/skills/run-litd/litd_setup.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# litd Installation Script for Ubuntu
+# This script automates the installation and configuration of Lightning Terminal (litd)
+
+set -e  # Exit on any command failure
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+GO_BIN_DIR="$USER_HOME/go/bin"
+GO_VERSION="1.23.9"
+NODE_VERSION="24.x"  # Stable Node.js version
+LITD_VERSION="v0.16.1-alpha"  # Version of litd to be installed
+
+# Ensure Go directory exists
+if [[ ! -d "$USER_HOME/go/bin" ]]; then
+    mkdir -p "$USER_HOME/go/bin"
+fi
+
+echo "[+] Ensuring $GO_BIN_DIR is owned by $(id -nu ${SUDO_USER:-$USER}):$(id -ng ${SUDO_USER:-$USER})..."
+sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/go"
+
+# Install Go
+echo "[+] Checking if Go $GO_VERSION is installed..."
+if command -v go &> /dev/null && [[ $(go version | awk '{print $3}' | cut -c3-) == "$GO_VERSION" ]]; then
+    echo "[+] Go $GO_VERSION is already installed. Skipping installation."
+else
+    echo "[+] Installing Go $GO_VERSION..."
+    wget -q "https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz" -O go.tar.gz
+    if [[ -f go.tar.gz ]]; then
+        sudo tar -C /usr/local -xzf go.tar.gz
+        rm go.tar.gz
+
+        # Update .profile for the invoking user
+        sudo -u ${SUDO_USER:-$USER} bash -c "
+        if ! grep -q 'export GOPATH=$USER_HOME/go' $USER_HOME/.profile; then
+            echo 'export GOPATH=$USER_HOME/go' >> $USER_HOME/.profile
+        fi
+        if ! grep -q 'export PATH=$USER_HOME/go/bin:/usr/local/go/bin:\$PATH' $USER_HOME/.profile; then
+            echo 'export PATH=$USER_HOME/go/bin:/usr/local/go/bin:\$PATH' >> $USER_HOME/.profile
+        fi
+        "
+
+        # Export variables for the current session
+        export GOPATH="$USER_HOME/go"
+        export PATH="$USER_HOME/go/bin:/usr/local/go/bin:$PATH"
+
+        echo "[+] Go $GO_VERSION installed successfully!"
+    else
+        echo "[-] Failed to download Go tarball. Exiting."
+        exit 1
+    fi
+fi
+
+# Install Node.js
+echo "[+] Checking if Node.js is installed..."
+if command -v node &> /dev/null && [[ $(node -v | grep -oP '\d+' | head -1) -ge 18 ]]; then
+    echo "[+] Node.js is already installed. Version: $(node -v)"
+else
+    echo "[+] Installing Node.js (stable release)..."
+    sudo apt-get install -y curl
+    curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION -o nodesource_setup.sh
+    sudo -E bash nodesource_setup.sh
+    sudo apt-get install -y nodejs
+    echo "[+] Node.js installed successfully. Version: $(node -v)"
+fi
+
+# Install Yarn
+echo "[+] Checking if Yarn is installed..."
+if command -v yarn &> /dev/null; then
+    echo "[+] Yarn is already installed. Version: $(yarn --version)"
+else
+    echo "[+] Installing Yarn..."
+    sudo npm install -g yarn
+    echo "[+] Yarn installed successfully. Version: $(yarn --version)"
+fi
+
+echo "[+] Installation and configuration complete!"
+echo "[+] Please verify that GoLang, NodeJS, and Yarn are properly installed."
+echo "[+] Then, end the current bash session and start a new one before running the next script."

--- a/skills/run-litd/litd_setup2.sh
+++ b/skills/run-litd/litd_setup2.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+
+# litd Installation Script for Ubuntu
+# This script automates the installation and configuration of Lightning Terminal (litd)
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_CONF_DIR="$USER_HOME/.lit"
+LIT_CONF_FILE="$LIT_CONF_DIR/lit.conf"
+LND_DIR="$USER_HOME/.lnd"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+GO_VERSION="1.23.9"
+NODE_VERSION="24.x"  # Ensure an even-numbered, stable release
+LITD_VERSION="v0.16.1-alpha"  # Version of litd to be installed
+SERVICE_FILE="/etc/systemd/system/litd.service"
+
+
+# Clone and build litd
+echo "[+] Checking if Lightning Terminal is already installed..."
+if [[ -f "$USER_HOME/go/bin/litd" ]]; then
+    echo "[+] Lightning Terminal (litd) is already installed. Skipping build."
+else
+    echo "[+] litd not found in $USER_HOME/go/bin. Proceeding with installation."
+
+    echo "[+] Ensuring $USER_HOME/go directory exists and is owned by the current user..."
+    if [[ -d "$USER_HOME/go" ]]; then
+        echo "[+] Directory $USER_HOME/go already exists."
+    else
+        echo "[+] Creating $USER_HOME/go directory..."
+        mkdir -p "$USER_HOME/go"
+        echo "[+] Directory $USER_HOME/go created successfully."
+    fi
+    echo "[+] Ensuring proper ownership of $USER_HOME/go..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/go"
+
+    # Ensure required build tools are installed
+    echo "[+] Checking for required build tools..."
+    if ! command -v make &> /dev/null; then
+        echo "[+] 'make' not found. Installing build-essential package..."
+        sudo apt update
+        sudo apt install build-essential -y
+    else
+        echo "[+] 'make' is already installed."
+    fi
+
+    echo "[+] Checking if Lightning Terminal repository already exists..."
+    if [[ -d "$USER_HOME/lightning-terminal" ]]; then
+        echo "[!] Repository already exists. Using existing directory."
+        cd "$USER_HOME/lightning-terminal"
+    else
+        echo "[+] Cloning Lightning Terminal repository into $USER_HOME/lightning-terminal..."
+        if git clone https://github.com/lightninglabs/lightning-terminal.git "$USER_HOME/lightning-terminal"; then
+            echo "[+] Repository cloned successfully."
+            cd "$USER_HOME/lightning-terminal"
+            # Ensure Lightning Terminal directory ownership
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/lightning-terminal"
+        else
+            echo "[-] Failed to clone repository. Check your internet connection and permissions."
+            exit 1
+        fi
+    fi
+
+    echo "[+] Checking out version $LITD_VERSION..."
+    if git checkout tags/$LITD_VERSION; then
+        echo "[+] Checked out version $LITD_VERSION."
+        echo "[+] Building litd... This might take a few minutes."
+        export GOPATH=$USER_HOME/go
+        export PATH=$USER_HOME/go/bin:/usr/local/go/bin:$PATH
+        if make install && make go-install-cli; then
+            echo "[+] litd successfully built and installed!"
+            # Ensure binary ownership
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/go"
+            
+            # Ensure lightning-terminal directory ownership
+            echo "[+] Ensuring proper ownership of $USER_HOME/lightning-terminal..."
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/lightning-terminal"
+        else
+            echo "[-] Failed to build and install litd. Check for errors in the build process."
+            exit 1
+        fi
+    else
+        echo "[-] Failed to checkout version $LITD_VERSION. Ensure the tag exists."
+        exit 1
+    fi
+fi
+
+# Ensure ~/.lnd directory exists
+echo "[+] Ensuring the ~/.lnd directory exists..."
+if [[ ! -d $LND_DIR ]]; then
+    mkdir -p $LND_DIR
+    echo "[+] Created directory at $LND_DIR."
+    # Ensure ~/.lnd directory is owned by the user
+    echo "[+] Ensuring ownership of $LND_DIR..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LND_DIR."
+else
+    echo "[!] Directory $LND_DIR already exists."
+fi
+
+# Generate wallet password
+echo "[+] Checking if wallet password file exists and is not empty..."
+if [[ -f $WALLET_PASSWORD_FILE && -s $WALLET_PASSWORD_FILE ]]; then
+    echo "[+] Wallet password file already exists and is not empty. Skipping generation."
+else
+    echo "[+] Generating wallet password..."
+    openssl rand -hex 21 > $WALLET_PASSWORD_FILE
+    if [[ -f $WALLET_PASSWORD_FILE ]]; then
+        echo "[+] Wallet password generated and saved to $WALLET_PASSWORD_FILE."
+        # Ensure wallet password file is owned by the user
+        echo "[+] Ensuring ownership of $WALLET_PASSWORD_FILE..."
+        sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $WALLET_PASSWORD_FILE
+        echo "[+] Ownership set to ${SUDO_USER:-$USER} for $WALLET_PASSWORD_FILE."
+    else
+        echo "[-] Failed to generate wallet password. Exiting."
+        exit 1
+    fi
+fi
+
+# Configure litd
+echo "[+] Step 4: Configuring Lightning Terminal (litd)..."
+
+# Check if configuration directory exists
+if [[ ! -d $LIT_CONF_DIR ]]; then
+    mkdir -p $LIT_CONF_DIR
+    echo "[+] Created configuration directory at $LIT_CONF_DIR."
+    # Ensure .lit directory is owned by the user
+    echo "[+] Ensuring ownership of $LIT_CONF_DIR..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_DIR
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LIT_CONF_DIR."
+else
+    echo "[!] $LIT_CONF_DIR already exists."
+fi
+
+# Check if configuration file exists and is not empty
+if [[ -f $LIT_CONF_FILE && -s $LIT_CONF_FILE ]]; then
+    echo "[+] Configuration file already exists and is not empty. Skipping creation."
+else
+    echo "[+] Generating new configuration file..."
+
+    read -p "Is your bitcoind backend running on mainnet or signet? [mainnet/signet]: " NETWORK
+    NETWORK=$(echo "$NETWORK" | tr '[:upper:]' '[:lower:]')
+    if [[ $NETWORK != "mainnet" && $NETWORK != "signet" ]]; then
+        echo "[-] Invalid network selection. Please choose either 'mainnet' or 'signet'."
+        exit 1
+    fi
+
+    read -s -p "Enter the RPC password for your bitcoind backend: " RPC_PASSWORD
+    echo
+    if [[ -z $RPC_PASSWORD ]]; then
+        echo "[-] RPC password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -s -p "Enter a UI password for litd: " UI_PASSWORD
+    echo
+    if [[ -z $UI_PASSWORD ]]; then
+        echo "[-] UI password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter a Lightning Node alias: " NODE_ALIAS
+
+    # Prepare the base configuration content
+    CONFIG_CONTENT="# Litd Settings
+enablerest=true
+httpslisten=0.0.0.0:8443
+uipassword=$UI_PASSWORD
+network=$NETWORK
+lnd-mode=integrated
+pool-mode=disable
+loop-mode=disable
+autopilot.disable=true
+
+# Bitcoin Configuration
+lnd.bitcoin.active=1
+lnd.bitcoin.node=bitcoind
+lnd.bitcoind.rpchost=127.0.0.1
+lnd.bitcoind.rpcuser=bitcoinrpc
+lnd.bitcoind.rpcpass=$RPC_PASSWORD
+lnd.bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+lnd.bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+
+# LND General Settings
+#lnd.wallet-unlock-password-file=/home/ubuntu/.lnd/wallet_password
+#lnd.wallet-unlock-allow-create=true
+lnd.debuglevel=debug
+lnd.alias=$NODE_ALIAS
+lnd.maxpendingchannels=3
+lnd.accept-keysend=true
+lnd.accept-amp=true
+lnd.rpcmiddleware.enable=true
+lnd.autopilot.active=0
+
+# LND Protocol Settings
+lnd.protocol.simple-taproot-chans=true
+lnd.protocol.simple-taproot-overlay-chans=true
+lnd.protocol.option-scid-alias=true
+lnd.protocol.zero-conf=true
+lnd.protocol.custom-message=17
+
+# Taproot Assets Settings
+#taproot-assets.rpclisten=0.0.0.0:10029
+#taproot-assets.allow-public-uni-proof-courier=true
+#taproot-assets.allow-public-stats=true
+#taproot-assets.universe.public-access=rw
+#taproot-assets.experimental.rfq.skipacceptquotepricecheck=true
+#taproot-assets.experimental.rfq.priceoracleaddress=rfqrpc://127.0.0.1:8095
+#taproot-assets.experimental.rfq.priceoracleaddress=use_mock_price_oracle_service_promise_to_not_use_on_mainnet
+#taproot-assets.experimental.rfq.mockoracleassetsperbtc=100000000"
+
+    # Apply mainnet-specific logic
+    if [[ $NETWORK == "mainnet" ]]; then
+        CONFIG_CONTENT=$(echo "$CONFIG_CONTENT" | sed "/pool-mode=disable/s/^/# /" | sed "/loop-mode=disable/s/^/# /" | sed "/autopilot.disable=true/s/^/# /")
+    fi
+
+    # Write configuration content to file
+    echo "$CONFIG_CONTENT" > $LIT_CONF_FILE
+    echo "[+] Configuration file created at $LIT_CONF_FILE."
+
+    # Ensure configuration file is owned by the user
+    echo "[+] Ensuring ownership of $LIT_CONF_FILE..."
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_FILE
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LIT_CONF_FILE."
+fi
+
+echo ""
+echo "[+] Build complete! Binaries are installed to $USER_HOME/go/bin."
+echo "    If litd or lncli are not found, start a new shell session or run:"
+echo "      source ~/.profile"
+echo ""
+echo "Now you have a task! Start litd with $ litd, do so as the user who will be running litd."
+echo "Walk through the wallet creation process using $ lncli --network=[yournetwork] create."
+echo "Use the already generated password which can be found via $ cat ~/.lnd/wallet_password"
+echo "DO NOT FORGET TO PROPERLY BACKUP YOUR SEED!!!"
+echo "Then, stop litd, and run the next script... almost there!!!"

--- a/skills/run-litd/litd_setup3.sh
+++ b/skills/run-litd/litd_setup3.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# litd Installation Script for Ubuntu
+# This script automates the installation and configuration of Lightning Terminal (litd)
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_CONF_DIR="$USER_HOME/.lit"
+LIT_CONF_FILE="$LIT_CONF_DIR/lit.conf"
+LND_DIR="$USER_HOME/.lnd"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SERVICE_FILE="/etc/systemd/system/litd.service"
+
+# Uncomment wallet unlock settings in the configuration file
+echo "[+] Uncommenting wallet unlock settings in the configuration file..."
+sed -i "s|^#lnd.wallet-unlock-password-file=/home/ubuntu/.lnd/wallet_password|lnd.wallet-unlock-password-file=$USER_HOME/.lnd/wallet_password|" $LIT_CONF_FILE
+sed -i "s|^#lnd.wallet-unlock-allow-create=true|lnd.wallet-unlock-allow-create=true|" $LIT_CONF_FILE
+
+echo "[+] Wallet unlock settings have been enabled in $LIT_CONF_FILE."   
+
+# Find the path to the litd binary using the original user’s login shell
+LITD_PATH=$(sudo -i -u "${SUDO_USER:-$USER}" which litd)
+
+# Ensure litd binary is found
+if [[ -z "$LITD_PATH" ]]; then
+    echo "[!] Error: 'litd' binary not found in PATH."
+    exit 1
+fi
+
+# Create systemd service file
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    echo "[+] Creating systemd service file for litd..."
+    cat <<EOF > $SERVICE_FILE
+[Unit]
+Description=Litd Terminal Daemon
+Requires=bitcoind.service
+After=bitcoind.service
+
+[Service]
+ExecStart=$LITD_PATH litd
+
+User=${SUDO_USER:-$USER}
+Group=${SUDO_USER:-$USER}
+
+Type=simple
+Restart=always
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+else
+    echo "[!] Systemd service file already exists. Skipping creation."
+fi
+
+# Enable, reload, and start systemd service
+systemctl enable litd
+systemctl daemon-reload
+if ! systemctl is-active --quiet litd; then
+    systemctl start litd
+    echo "[+] litd service started."
+else
+    echo "[!] litd service is already running."
+fi
+
+cat <<'EOF'
+
+[+] Lightning Terminal Daemon (litd) built, configured, and service enabled successfully!
+
+
+             ________________________________________________
+            /                                                \
+           |    _________________________________________     |
+           |   |                                         |    |
+           |   |       ___(                        )     |    |
+           |   |      (                          _)      |    |
+           |   |     (_                       __))       |    |
+           |   |       ((                _____)          |    |
+           |   |         (_________)----'                |    |
+           |   |              _/  /                      |    |
+           |   |             /  _/                       |    |
+           |   |           _/  /                         |    |
+           |   |          / __/                          |    |
+           |   |        _/ /                             |    |
+           |   |       /__/                              |    |
+           |   |      /'                                 |    |
+           |   |_________________________________________|    |
+           |                                                  |
+            \_________________________________________________/
+                   \___________________________________/
+                ___________________________________________
+             _-'    .-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.  --- `-_
+          _-'.-.-. .---.-.-.-.-.-.-.-.-.-.-.-.-.-.-.--.  .-.-.`-_
+       _-'.-.-.-. .---.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-`__`. .-.-.-.`-_
+    _-'.-.-.-.-. .-----.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-----. .-.-.-.-.`-_
+ _-'.-.-.-.-.-. .---.-. .-------------------------. .-.---. .---.-.-.-.`-_
+:-------------------------------------------------------------------------:
+`---._.-------------------------------------------------------------._.---'
+
+[+] Your Litd node is now up and running!
+EOF

--- a/skills/run-litd/litd_setup_binary.sh
+++ b/skills/run-litd/litd_setup_binary.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+
+# litd Installation Script for Ubuntu
+# This script automates the installation and configuration of Lightning Terminal (litd)
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_CONF_DIR="$USER_HOME/.lit"
+LIT_CONF_FILE="$LIT_CONF_DIR/lit.conf"
+LND_DIR="$USER_HOME/.lnd"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SERVICE_FILE="/etc/systemd/system/litd.service"
+
+LITD_VERSION="v0.16.1-alpha"  # Version of litd to be installed
+BINARY_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/lightning-terminal-linux-amd64-$LITD_VERSION.tar.gz"
+SIGNATURE_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/manifest-ellemouton-$LITD_VERSION.sig"
+MANIFEST_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/manifest-$LITD_VERSION.txt"
+KEY_ID="26984CB69EB8C4A26196F7A4D7D916376026F177"
+KEY_SERVER="hkps://keyserver.ubuntu.com"
+DOWNLOAD_DIR="/tmp/litd_release_verification"
+
+
+# Install litd from binary
+echo "[+] Checking if Lightning Terminal is already installed..."
+if [[ -f "/usr/local/bin/litd" ]]; then
+    echo "[+] Lightning Terminal (litd) is already installed. Skipping installation."
+else
+    echo "[+] litd not found in /usr/local/bin. Proceeding with installation."
+
+    # Create download directory
+    mkdir -p "$DOWNLOAD_DIR"
+    cd "$DOWNLOAD_DIR" || { echo "Failed to navigate to download directory."; exit 1; }
+    echo "The current working directory is: $PWD"
+
+    # Import Signing key
+    echo "Importing Signing key..."
+    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "Failed to import PGP key."; exit 1; }
+
+    # Download litd binary
+    echo "Downloading binary..."
+    wget "$BINARY_URL" || { echo "Failed to download binary."; exit 1; }
+
+    echo "Downloading signature..."
+    wget "$SIGNATURE_URL" || { echo "Failed to download signature."; exit 1; }
+
+    echo "Downloading manifest..."
+    wget "$MANIFEST_URL" || { echo "Failed to download manifest."; exit 1; }
+
+    # Verify the release signature
+    echo "Verifying signature..."
+    gpg --verify "$(basename "$SIGNATURE_URL")" "$(basename "$MANIFEST_URL")" 2>&1 | grep "$KEY_ID" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "Signature verification successful."
+    else
+        echo "Signature verification failed or does not match the expected key ID: $KEY_ID."
+        exit 1
+    fi
+
+    #Check SHASUM
+    echo "Checking shasum..."
+    grep "$(sha256sum "$(basename "$BINARY_URL")" | awk '{print $1}')" "$(basename "$MANIFEST_URL")" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "SHA256 hash verification successful."
+    else
+        echo "SHA256 hash verification failed."
+        exit 1
+    fi
+
+    echo "[+] Extracting litd binary..."
+    tar -xvzf "$DOWNLOAD_DIR/lightning-terminal-linux-amd64-$LITD_VERSION.tar.gz" -C "$DOWNLOAD_DIR" --strip-components=1
+
+    echo "[+] Installing binaries to /usr/local/bin..."
+    find "$DOWNLOAD_DIR" -maxdepth 1 -type f -executable -exec sudo install -m 0755 -o root -g root {} /usr/local/bin/ \;
+
+    echo "[+] Cleaning up temporary files..."
+    rm -rf "$DOWNLOAD_DIR"
+
+    echo "[+] litd successfully installed!"
+
+    # Change back to the ubuntu user's home directory
+    cd "$USER_HOME" || { echo "Failed to return to the user's home directory: $USER_HOME"; exit 1; }
+fi
+
+# Ensure ~/.lnd directory exists
+echo "[+] Ensuring the ~/.lnd directory exists..."
+if [[ ! -d $LND_DIR ]]; then
+    mkdir -p $LND_DIR
+    echo "[+] Created directory at $LND_DIR."
+    # Ensure ~/.lnd directory is owned by the user
+    echo "[+] Ensuring ownership of $LND_DIR..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LND_DIR."
+else
+    echo "[!] Directory $LND_DIR already exists."
+fi
+
+# Generate wallet password
+echo "[+] Checking if wallet password file exists and is not empty..."
+if [[ -f $WALLET_PASSWORD_FILE && -s $WALLET_PASSWORD_FILE ]]; then
+    echo "[+] Wallet password file already exists and is not empty. Skipping generation."
+else
+    echo "[+] Generating wallet password..."
+    openssl rand -hex 21 > $WALLET_PASSWORD_FILE
+    chmod 600 $WALLET_PASSWORD_FILE
+    if [[ -f $WALLET_PASSWORD_FILE ]]; then
+        echo "[+] Wallet password generated and saved to $WALLET_PASSWORD_FILE."
+        # Ensure wallet password file is owned by the user
+        echo "[+] Ensuring ownership of $WALLET_PASSWORD_FILE..."
+        sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $WALLET_PASSWORD_FILE
+        echo "[+] Ownership set to ${SUDO_USER:-$USER} for $WALLET_PASSWORD_FILE."
+    else
+        echo "[-] Failed to generate wallet password. Exiting."
+        exit 1
+    fi
+fi
+
+# Configure litd
+echo "[+] Step 4: Configuring Lightning Terminal (litd)..."
+
+# Check if configuration directory exists
+if [[ ! -d $LIT_CONF_DIR ]]; then
+    mkdir -p $LIT_CONF_DIR
+    echo "[+] Created configuration directory at $LIT_CONF_DIR."
+    # Ensure .lit directory is owned by the user
+    echo "[+] Ensuring ownership of $LIT_CONF_DIR..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_DIR
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LIT_CONF_DIR."
+else
+    echo "[!] $LIT_CONF_DIR already exists."
+fi
+
+# Check if configuration file exists and is not empty
+if [[ -f $LIT_CONF_FILE && -s $LIT_CONF_FILE ]]; then
+    echo "[+] Configuration file already exists and is not empty. Skipping creation."
+else
+    echo "[+] Generating new configuration file..."
+
+    read -p "Is your bitcoind backend running on mainnet or signet? [mainnet/signet]: " NETWORK
+    NETWORK=$(echo "$NETWORK" | tr '[:upper:]' '[:lower:]')
+    if [[ $NETWORK != "mainnet" && $NETWORK != "signet" ]]; then
+        echo "[-] Invalid network selection. Please choose either 'mainnet' or 'signet'."
+        exit 1
+    fi
+
+    read -s -p "Enter the RPC password for your bitcoind backend: " RPC_PASSWORD
+    echo
+    if [[ -z $RPC_PASSWORD ]]; then
+        echo "[-] RPC password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -s -p "Enter a UI password for litd: " UI_PASSWORD
+    echo
+    if [[ -z $UI_PASSWORD ]]; then
+        echo "[-] UI password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter a Lightning Node alias: " NODE_ALIAS
+
+    # Prepare the base configuration content
+    CONFIG_CONTENT="# Litd Settings
+enablerest=true
+httpslisten=0.0.0.0:8443
+uipassword=$UI_PASSWORD
+network=$NETWORK
+lnd-mode=integrated
+pool-mode=disable
+loop-mode=disable
+autopilot.disable=true
+
+# Bitcoin Configuration
+lnd.bitcoin.active=1
+lnd.bitcoin.node=bitcoind
+lnd.bitcoind.rpchost=127.0.0.1
+lnd.bitcoind.rpcuser=bitcoinrpc
+lnd.bitcoind.rpcpass=$RPC_PASSWORD
+lnd.bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+lnd.bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+
+# LND General Settings
+#lnd.wallet-unlock-password-file=/home/ubuntu/.lnd/wallet_password
+#lnd.wallet-unlock-allow-create=true
+lnd.debuglevel=debug
+lnd.alias=$NODE_ALIAS
+lnd.maxpendingchannels=3
+lnd.accept-keysend=true
+lnd.accept-amp=true
+lnd.rpcmiddleware.enable=true
+lnd.autopilot.active=0
+
+# LND Protocol Settings
+lnd.protocol.simple-taproot-chans=true
+lnd.protocol.simple-taproot-overlay-chans=true
+lnd.protocol.option-scid-alias=true
+lnd.protocol.zero-conf=true
+lnd.protocol.custom-message=17
+
+# Taproot Assets Settings
+#taproot-assets.rpclisten=0.0.0.0:10029
+#taproot-assets.allow-public-uni-proof-courier=true
+#taproot-assets.allow-public-stats=true
+#taproot-assets.universe.public-access=rw
+#taproot-assets.experimental.rfq.skipacceptquotepricecheck=true
+#taproot-assets.experimental.rfq.priceoracleaddress=rfqrpc://127.0.0.1:8095
+#taproot-assets.experimental.rfq.priceoracleaddress=use_mock_price_oracle_service_promise_to_not_use_on_mainnet
+#taproot-assets.experimental.rfq.mockoracleassetsperbtc=100000000"
+
+    # Apply mainnet-specific logic
+    if [[ $NETWORK == "mainnet" ]]; then
+        CONFIG_CONTENT=$(echo "$CONFIG_CONTENT" | sed "/pool-mode=disable/s/^/# /" | sed "/loop-mode=disable/s/^/# /" | sed "/autopilot.disable=true/s/^/# /")
+    fi
+
+    # Write configuration content to file
+    echo "$CONFIG_CONTENT" > $LIT_CONF_FILE
+    echo "[+] Configuration file created at $LIT_CONF_FILE."
+
+    # Ensure configuration file is owned by the user
+    echo "[+] Ensuring ownership of $LIT_CONF_FILE..."
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_FILE
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LIT_CONF_FILE."
+fi
+
+echo "Now you have a task! Start litd with $ litd, do so as the user who will be running litd."
+echo "In a new tab..."
+echo "Walk through the wallet creation process using $ lncli --network=[yournetwork] create."
+echo "Use the already generated password which can be found via $ cat ~/.lnd/wallet_password"
+echo "DO NOT FORGET TO PROPERLY BACKUP YOUR SEED!!!" 
+echo "Then, stop litd, and run the next script... almost there!!!"

--- a/skills/run-litd/litd_wallet_create.sh
+++ b/skills/run-litd/litd_wallet_create.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# litd Wallet Creation Script
+# Tested on Ubuntu 24.04
+#
+# Run this after neutrino_setup_binary.sh or litd_setup_binary.sh,
+# and before neutrino_setup3.sh or litd_setup3.sh.
+#
+# Starts litd temporarily, creates the LND wallet via REST API,
+# then stops litd. Equivalent to the automated wallet creation in
+# the remote signer scripts — no manual lncli create step needed.
+
+set -e
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_DIR="$USER_HOME/.lit"
+LIT_CONF_FILE="$LIT_DIR/lit.conf"
+LND_DIR="$USER_HOME/.lnd"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SEED_FILE="$LND_DIR/seed_phrase.txt"
+TLS_CERT="$LIT_DIR/tls.cert"
+TIMEOUT=180
+LITD_PID=""
+
+# Check root
+if [[ $EUID -ne 0 ]]; then
+    echo "[-] This script must be run as root. Use sudo."
+    exit 1
+fi
+
+# Install dependencies
+apt-get install -y curl jq > /dev/null 2>&1
+
+# Check prerequisites
+if [[ ! -f "$WALLET_PASSWORD_FILE" || ! -s "$WALLET_PASSWORD_FILE" ]]; then
+    echo "[-] Wallet password file not found: $WALLET_PASSWORD_FILE"
+    echo "    Run the setup script first."
+    exit 1
+fi
+
+if [[ ! -f "$LIT_CONF_FILE" || ! -s "$LIT_CONF_FILE" ]]; then
+    echo "[-] lit.conf not found: $LIT_CONF_FILE"
+    echo "    Run the setup script first."
+    exit 1
+fi
+
+# Check if litd is already running
+if pgrep -x litd > /dev/null; then
+    echo "[-] litd is already running. Stop it before running this script."
+    exit 1
+fi
+
+# Detect network from lit.conf
+if grep -q "lnd.bitcoin.signet=1" "$LIT_CONF_FILE" 2>/dev/null; then
+    NETWORK="signet"
+else
+    NETWORK="mainnet"
+fi
+
+MACAROON_PATH="$LND_DIR/data/chain/bitcoin/$NETWORK/admin.macaroon"
+
+# Check if wallet already exists
+if [[ -f "$MACAROON_PATH" ]]; then
+    echo "[!] Wallet already initialized. Skipping."
+    exit 0
+fi
+
+# Stop litd on exit (success or failure)
+cleanup() {
+    if [[ -n "$LITD_PID" ]] && kill -0 "$LITD_PID" 2>/dev/null; then
+        echo "[+] Stopping litd..."
+        kill "$LITD_PID"
+        wait "$LITD_PID" 2>/dev/null || true
+        echo "[+] litd stopped."
+    fi
+}
+trap cleanup EXIT
+
+# Start litd in background as the regular user
+echo "[+] Starting litd for wallet creation..."
+LITD_PATH=$(which litd)
+sudo -u ${SUDO_USER:-$USER} "$LITD_PATH" &
+LITD_PID=$!
+
+# Wait for TLS cert
+echo "[+] Waiting for litd TLS certificate..."
+ELAPSED=0
+while [[ ! -f "$TLS_CERT" ]]; do
+    sleep 2; ELAPSED=$((ELAPSED + 2))
+    if [[ $ELAPSED -ge $TIMEOUT ]]; then echo "[-] Timed out waiting for TLS cert."; exit 1; fi
+done
+echo "[+] TLS certificate ready."
+
+# Wait for REST API
+echo "[+] Waiting for litd REST API..."
+ELAPSED=0
+while ! curl -sf --cacert "$TLS_CERT" https://localhost:8443/v1/state > /dev/null 2>&1; do
+    sleep 2; ELAPSED=$((ELAPSED + 2))
+    if [[ $ELAPSED -ge $TIMEOUT ]]; then echo "[-] Timed out waiting for REST API."; exit 1; fi
+done
+echo "[+] litd REST API ready."
+
+# Generate seed
+echo "[+] Generating wallet seed..."
+SEED_JSON=$(curl -sf --cacert "$TLS_CERT" https://localhost:8443/v1/genseed)
+if [[ -z "$SEED_JSON" ]]; then echo "[-] Failed to generate seed."; exit 1; fi
+
+MNEMONIC=$(echo "$SEED_JSON" | jq -r '.cipher_seed_mnemonic | join(" ")')
+MNEMONIC_ARRAY=$(echo "$SEED_JSON" | jq -c '.cipher_seed_mnemonic')
+
+echo "$MNEMONIC" > "$SEED_FILE"
+chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$SEED_FILE"
+chmod 600 "$SEED_FILE"
+
+echo ""
+echo "============================================================"
+echo "  !! WALLET SEED PHRASE - BACK THIS UP IMMEDIATELY !!      "
+echo "  This is your ONLY recovery option if this node is lost.  "
+echo "============================================================"
+echo "$MNEMONIC"
+echo "============================================================"
+echo "  Saved to: $SEED_FILE  (chmod 600)"
+echo "  Once backed up, delete it:  shred -u $SEED_FILE"
+echo "============================================================"
+echo ""
+
+# Initialize wallet
+echo "[+] Initializing wallet..."
+WALLET_PASSWORD_B64=$(tr -d '\n' < "$WALLET_PASSWORD_FILE" | base64 -w 0)
+INIT_RESPONSE=$(curl -sf --cacert "$TLS_CERT" \
+    -X POST https://localhost:8443/v1/initwallet \
+    -H 'Content-Type: application/json' \
+    -d "{\"wallet_password\": \"$WALLET_PASSWORD_B64\", \"cipher_seed_mnemonic\": $MNEMONIC_ARRAY}")
+
+if [[ -z "$INIT_RESPONSE" ]]; then echo "[-] No response from initwallet."; exit 1; fi
+if echo "$INIT_RESPONSE" | jq -e '.code' > /dev/null 2>&1; then
+    echo "[-] Wallet init failed: $(echo "$INIT_RESPONSE" | jq -r '.message')"
+    exit 1
+fi
+echo "[+] Wallet initialized, waiting for unlock..."
+
+# Wait for macaroon
+ELAPSED=0
+while [[ ! -f "$MACAROON_PATH" ]]; do
+    sleep 2; ELAPSED=$((ELAPSED + 2))
+    if [[ $ELAPSED -ge $TIMEOUT ]]; then echo "[-] Timed out waiting for wallet unlock."; exit 1; fi
+done
+echo "[+] Wallet unlocked."
+
+cat <<"EOF"
+
+[+] Wallet creation complete!
+
+IMPORTANT: Back up your seed phrase then delete it from disk:
+  shred -u ~/.lnd/seed_phrase.txt
+
+Next step: run the setup3 script to enable auto-unlock and the systemd service.
+
+EOF

--- a/skills/run-litd/neutrino/neutrino_setup3.sh
+++ b/skills/run-litd/neutrino/neutrino_setup3.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# litd Neutrino Setup — Final Step
+# Tested on Ubuntu 24.04
+#
+# Enables wallet auto-unlock and registers litd as a systemd service.
+# Run this after completing wallet creation with `lncli --network=<network> create`.
+#
+# Unlike litd_setup3.sh, this service has no bitcoind dependency.
+
+set -e
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_CONF_FILE="$USER_HOME/.lit/lit.conf"
+SERVICE_FILE="/etc/systemd/system/litd.service"
+
+# Check root
+if [[ $EUID -ne 0 ]]; then
+    echo "[-] This script must be run as root. Use sudo."
+    exit 1
+fi
+
+# Check config file exists
+if [[ ! -f "$LIT_CONF_FILE" ]]; then
+    echo "[-] lit.conf not found at $LIT_CONF_FILE."
+    echo "    Run neutrino_setup_binary.sh first."
+    exit 1
+fi
+
+# Enable wallet auto-unlock
+echo "[+] Enabling wallet auto-unlock in lit.conf..."
+sed -i "s|^#lnd.wallet-unlock-password-file=.*|lnd.wallet-unlock-password-file=$USER_HOME/.lnd/wallet_password|" $LIT_CONF_FILE
+sed -i "s|^#lnd.wallet-unlock-allow-create=true|lnd.wallet-unlock-allow-create=true|" $LIT_CONF_FILE
+echo "[+] Wallet auto-unlock enabled."
+
+# Find litd binary
+LITD_PATH=$(sudo -i -u "${SUDO_USER:-$USER}" which litd)
+if [[ -z "$LITD_PATH" ]]; then
+    echo "[-] litd binary not found in PATH. Check that /usr/local/bin is in PATH."
+    exit 1
+fi
+
+# Create systemd service (no bitcoind dependency — Neutrino handles its own Bitcoin connection)
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    echo "[+] Creating systemd service for litd..."
+    cat <<EOF > $SERVICE_FILE
+[Unit]
+Description=Lightning Terminal Daemon (Neutrino)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=$LITD_PATH
+
+User=${SUDO_USER:-$USER}
+Group=${SUDO_USER:-$USER}
+
+Type=simple
+Restart=always
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    echo "[+] Systemd service file created."
+else
+    echo "[!] Systemd service file already exists. Skipping creation."
+fi
+
+# Enable and start service
+systemctl enable litd
+systemctl daemon-reload
+if ! systemctl is-active --quiet litd; then
+    systemctl start litd
+    echo "[+] litd service started."
+else
+    echo "[!] litd service is already running."
+fi
+
+cat <<'EOF'
+
+[+] Lightning Terminal Daemon (litd) with Neutrino is now running as a systemd service!
+
+    Verify with:
+      systemctl status litd
+      journalctl -fu litd
+      lncli --network=<signet|mainnet> getinfo
+
+    Neutrino syncs from peers — allow a few minutes for synced_to_chain: true.
+
+EOF

--- a/skills/run-litd/neutrino/neutrino_setup_binary.sh
+++ b/skills/run-litd/neutrino/neutrino_setup_binary.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+# litd Setup Script with Neutrino Backend (Binary Install)
+# Tested on Ubuntu 24.04
+#
+# Neutrino is a lightweight SPV Bitcoin client built into LND — no bitcoind required.
+# Use this script instead of bitcoind_setup_binary.sh + litd_setup_binary.sh.
+#
+# NOTE: Neutrino is suitable for signet and development. It is NOT recommended for
+# mainnet production routing nodes — it depends on external peers for block data,
+# so if those peers go down or are overloaded, your node suffers.
+# For a mainnet routing node, use bitcoind_setup_binary.sh + litd_setup_binary.sh.
+
+set -e
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_CONF_DIR="$USER_HOME/.lit"
+LIT_CONF_FILE="$LIT_CONF_DIR/lit.conf"
+LND_DIR="$USER_HOME/.lnd"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+
+LITD_VERSION="v0.16.1-alpha"
+BINARY_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/lightning-terminal-linux-amd64-$LITD_VERSION.tar.gz"
+SIGNATURE_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/manifest-ellemouton-$LITD_VERSION.sig"
+MANIFEST_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/manifest-$LITD_VERSION.txt"
+KEY_ID="26984CB69EB8C4A26196F7A4D7D916376026F177"
+KEY_SERVER="hkps://keyserver.ubuntu.com"
+DOWNLOAD_DIR="/tmp/litd_release_verification"
+
+# Default Neutrino peers
+# These must support BIP 157/158 compact block filters.
+MAINNET_PEERS=(
+    "btcd-mainnet.lightning.computer:8333"
+    "node.lightning.directory:8333"
+)
+SIGNET_PEERS=(
+    "172.233.20.188:38333"
+)
+
+# Check root
+if [[ $EUID -ne 0 ]]; then
+    echo "[-] This script must be run as root. Use sudo."
+    exit 1
+fi
+
+# Install litd from binary
+echo "[+] Checking if Lightning Terminal is already installed..."
+if [[ -f "/usr/local/bin/litd" ]]; then
+    echo "[+] litd is already installed. Skipping installation."
+else
+    echo "[+] litd not found. Proceeding with installation."
+
+    mkdir -p "$DOWNLOAD_DIR"
+    cd "$DOWNLOAD_DIR" || { echo "[-] Failed to navigate to download directory."; exit 1; }
+
+    echo "[+] Importing signing key..."
+    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+
+    echo "[+] Downloading litd binary, signature, and manifest..."
+    wget "$BINARY_URL"   || { echo "[-] Failed to download binary."; exit 1; }
+    wget "$SIGNATURE_URL" || { echo "[-] Failed to download signature."; exit 1; }
+    wget "$MANIFEST_URL"  || { echo "[-] Failed to download manifest."; exit 1; }
+
+    echo "[+] Verifying signature..."
+    gpg --verify "$(basename "$SIGNATURE_URL")" "$(basename "$MANIFEST_URL")" 2>&1 | grep "$KEY_ID" > /dev/null
+    if [[ $? -eq 0 ]]; then
+        echo "[+] Signature verified."
+    else
+        echo "[-] Signature verification failed. Exiting."
+        exit 1
+    fi
+
+    echo "[+] Verifying SHA256 checksum..."
+    grep "$(sha256sum "$(basename "$BINARY_URL")" | awk '{print $1}')" "$(basename "$MANIFEST_URL")" > /dev/null
+    if [[ $? -eq 0 ]]; then
+        echo "[+] SHA256 verified."
+    else
+        echo "[-] SHA256 verification failed. Exiting."
+        exit 1
+    fi
+
+    echo "[+] Extracting and installing litd..."
+    tar -xvzf "$DOWNLOAD_DIR/lightning-terminal-linux-amd64-$LITD_VERSION.tar.gz" -C "$DOWNLOAD_DIR" --strip-components=1
+    find "$DOWNLOAD_DIR" -maxdepth 1 -type f -executable -exec sudo install -m 0755 -o root -g root {} /usr/local/bin/ \;
+    rm -rf "$DOWNLOAD_DIR"
+    echo "[+] litd installed successfully."
+
+    cd "$USER_HOME" || { echo "[-] Failed to return to home directory."; exit 1; }
+fi
+
+# Set up ~/.lnd directory
+echo "[+] Ensuring ~/.lnd directory exists..."
+if [[ ! -d $LND_DIR ]]; then
+    mkdir -p $LND_DIR
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+    echo "[+] Created $LND_DIR."
+else
+    echo "[!] $LND_DIR already exists."
+fi
+
+# Generate wallet password
+echo "[+] Checking for wallet password file..."
+if [[ -f $WALLET_PASSWORD_FILE && -s $WALLET_PASSWORD_FILE ]]; then
+    echo "[+] Wallet password already exists. Skipping."
+else
+    echo "[+] Generating wallet password..."
+    openssl rand -hex 21 > $WALLET_PASSWORD_FILE
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $WALLET_PASSWORD_FILE
+    echo "[+] Wallet password saved to $WALLET_PASSWORD_FILE."
+fi
+
+# Configure lit.conf
+if [[ -f $LIT_CONF_FILE && -s $LIT_CONF_FILE ]]; then
+    echo "[+] Configuration file already exists. Skipping."
+else
+    echo "[+] Configuring litd with Neutrino backend..."
+
+    # Network selection
+    while true; do
+        read -p "Which network? [mainnet/signet]: " NETWORK
+        NETWORK=$(echo "$NETWORK" | tr '[:upper:]' '[:lower:]')
+        if [[ "$NETWORK" == "mainnet" || "$NETWORK" == "signet" ]]; then
+            break
+        fi
+        echo "[-] Please enter 'mainnet' or 'signet'."
+    done
+
+    # Warn on mainnet
+    if [[ "$NETWORK" == "mainnet" ]]; then
+        echo ""
+        echo "[!] WARNING: Neutrino is not recommended for mainnet production routing nodes."
+        echo "    It depends on external peers for block data — if peers go down or are"
+        echo "    overloaded, your node suffers. For a production routing node, use"
+        echo "    bitcoind_setup_binary.sh + litd_setup_binary.sh instead."
+        echo ""
+        read -p "Continue with Neutrino on mainnet anyway? (yes/no): " CONFIRM
+        if [[ "$CONFIRM" != "yes" ]]; then
+            echo "[-] Exiting. Run bitcoind_setup_binary.sh + litd_setup_binary.sh for mainnet."
+            exit 0
+        fi
+    fi
+
+    read -s -p "Enter a UI password for litd: " UI_PASSWORD
+    echo
+    if [[ -z $UI_PASSWORD ]]; then
+        echo "[-] UI password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter a Lightning Node alias: " NODE_ALIAS
+
+    # Set network-specific values
+    if [[ "$NETWORK" == "mainnet" ]]; then
+        DEFAULT_PEERS=("${MAINNET_PEERS[@]}")
+        NETWORK_FLAG="lnd.bitcoin.mainnet=1"
+        FEE_LINE="lnd.neutrino.feeurl=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json"
+        SIGNET_OPTS="#pool-mode=disable
+#loop-mode=disable
+#autopilot.disable=true"
+    else
+        DEFAULT_PEERS=("${SIGNET_PEERS[@]}")
+        NETWORK_FLAG="lnd.bitcoin.signet=1"
+        FEE_LINE=""
+        SIGNET_OPTS="pool-mode=disable
+loop-mode=disable
+autopilot.disable=true"
+    fi
+
+    # Build peer config lines
+    PEER_CONFIG=""
+    echo ""
+    echo "[+] Default Neutrino peers for $NETWORK:"
+    for PEER in "${DEFAULT_PEERS[@]}"; do
+        echo "    $PEER"
+        PEER_CONFIG+="lnd.neutrino.connect=$PEER"$'\n'
+    done
+
+    read -p "Add additional Neutrino peers? (comma-separated, or press Enter to skip): " EXTRA_PEERS
+    if [[ -n "$EXTRA_PEERS" ]]; then
+        IFS=',' read -ra EXTRA_PEER_ARRAY <<< "$EXTRA_PEERS"
+        for PEER in "${EXTRA_PEER_ARRAY[@]}"; do
+            PEER=$(echo "$PEER" | tr -d '[:space:]')
+            PEER_CONFIG+="lnd.neutrino.connect=$PEER"$'\n'
+        done
+    fi
+
+    mkdir -p $LIT_CONF_DIR
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_DIR
+
+    cat > $LIT_CONF_FILE <<EOF
+# litd Settings
+enablerest=true
+httpslisten=0.0.0.0:8443
+uipassword=$UI_PASSWORD
+network=$NETWORK
+lnd-mode=integrated
+$SIGNET_OPTS
+
+# Bitcoin Configuration (Neutrino — no bitcoind required)
+lnd.bitcoin.active=1
+lnd.bitcoin.node=neutrino
+$NETWORK_FLAG
+
+# Neutrino Peers (must support BIP 157/158 compact block filters)
+${PEER_CONFIG}${FEE_LINE}
+
+# LND General Settings
+#lnd.wallet-unlock-password-file=$USER_HOME/.lnd/wallet_password
+#lnd.wallet-unlock-allow-create=true
+lnd.debuglevel=debug
+lnd.alias=$NODE_ALIAS
+lnd.maxpendingchannels=3
+lnd.accept-keysend=true
+lnd.accept-amp=true
+lnd.rpcmiddleware.enable=true
+lnd.autopilot.active=0
+
+# LND Protocol Settings
+lnd.protocol.simple-taproot-chans=true
+lnd.protocol.simple-taproot-overlay-chans=true
+lnd.protocol.option-scid-alias=true
+lnd.protocol.zero-conf=true
+lnd.protocol.custom-message=17
+
+# Taproot Assets Settings (uncomment to enable)
+#taproot-assets.rpclisten=0.0.0.0:10029
+#taproot-assets.allow-public-uni-proof-courier=true
+#taproot-assets.allow-public-stats=true
+#taproot-assets.universe.public-access=rw
+EOF
+
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_FILE
+    echo "[+] Configuration file created at $LIT_CONF_FILE."
+fi
+
+echo ""
+echo "[+] litd is configured with Neutrino — no bitcoind required!"
+echo ""
+echo "    Next steps:"
+echo "    1. Start litd manually as the non-root user:"
+echo "       $ litd"
+echo ""
+echo "    2. In a new terminal tab, create the LND wallet:"
+echo "       $ lncli --network=$NETWORK create"
+echo "       Use the password from: cat $WALLET_PASSWORD_FILE"
+echo "       BACK UP YOUR SEED PHRASE."
+echo ""
+echo "    3. Stop litd (Ctrl-C), then run the final script:"
+echo "       $ sudo ./neutrino_setup3.sh"

--- a/skills/run-litd/neutrino/remote-signer-neutrino-binary.sh
+++ b/skills/run-litd/neutrino/remote-signer-neutrino-binary.sh
@@ -1,0 +1,389 @@
+#!/bin/bash
+
+# LND Remote Signer Setup Script with Neutrino Backend (Binary Install)
+# Tested on Ubuntu 24.04
+#
+# Sets up an LND remote signer node using Neutrino as the Bitcoin backend.
+# No bitcoind required — Neutrino connects directly to peers that support
+# BIP 157/158 compact block filters.
+#
+# Use this on the SIGNER machine. The signer holds private keys, should not
+# be internet-exposed, and only needs to be reachable by the routing node.
+#
+# After this script completes, copy three files to the routing node:
+#   ~/.lnd/tls.cert       → rename to signer-tls.cert on routing node
+#   ~/.lnd/signer.macaroon
+#   ~/.lnd/accounts.json
+
+set -e
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LND_DIR="$USER_HOME/.lnd"
+LND_CONF_FILE="$LND_DIR/lnd.conf"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SERVICE_FILE="/etc/systemd/system/lnd.service"
+LND_VERSION="v0.20.1-beta"
+BINARY_URL="https://github.com/lightningnetwork/lnd/releases/download/$LND_VERSION/lnd-linux-amd64-$LND_VERSION.tar.gz"
+MANIFEST_URL="https://github.com/lightningnetwork/lnd/releases/download/$LND_VERSION/manifest-$LND_VERSION.txt"
+SIGNATURE_URL="https://github.com/lightningnetwork/lnd/releases/download/$LND_VERSION/manifest-roasbeef-$LND_VERSION.sig"
+KEY_ID="296212681AADF05656A2CDEE90525F7DEEE0AD86"
+KEY_SERVER="hkps://keyserver.ubuntu.com"
+DOWNLOAD_DIR="/tmp/lnd_release_verification"
+
+# Default Neutrino peers (must support BIP 157/158 compact block filters)
+MAINNET_PEERS=(
+    "btcd-mainnet.lightning.computer:8333"
+    "node.lightning.directory:8333"
+)
+SIGNET_PEERS=(
+    "172.233.20.188:38333"
+)
+
+# Check root
+if [[ $EUID -ne 0 ]]; then
+    echo "[-] This script must be run as root. Use sudo."
+    exit 1
+fi
+
+# Install dependencies
+echo "[+] Installing dependencies..."
+apt-get update
+apt-get install -y curl jq wget
+
+# Install LND from binary
+echo "[+] Checking if LND is already installed..."
+if [[ -f "/usr/local/bin/lnd" && -f "/usr/local/bin/lncli" ]]; then
+    echo "[+] LND is already installed. Skipping."
+else
+    mkdir -p "$DOWNLOAD_DIR"
+    cd "$DOWNLOAD_DIR" || { echo "[-] Failed to navigate to download directory."; exit 1; }
+
+    echo "[+] Importing LND signing key..."
+    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+
+    echo "[+] Downloading LND binary, manifest, and signature..."
+    wget "$BINARY_URL"    || { echo "[-] Failed to download binary."; exit 1; }
+    wget "$MANIFEST_URL"  || { echo "[-] Failed to download manifest."; exit 1; }
+    wget "$SIGNATURE_URL" || { echo "[-] Failed to download signature."; exit 1; }
+
+    echo "[+] Verifying PGP signature..."
+    GPG_OUTPUT=$(gpg --verify "$(basename "$SIGNATURE_URL")" "$(basename "$MANIFEST_URL")" 2>&1 || true)
+    if echo "$GPG_OUTPUT" | grep -q "$KEY_ID"; then
+        echo "[+] Signature verified."
+    else
+        echo "[-] Signature verification failed. Exiting."
+        echo "$GPG_OUTPUT"
+        exit 1
+    fi
+
+    echo "[+] Verifying SHA256 checksum..."
+    BINARY_HASH=$(sha256sum "$(basename "$BINARY_URL")" | awk '{print $1}')
+    if grep -q "$BINARY_HASH" "$(basename "$MANIFEST_URL")"; then
+        echo "[+] SHA256 verified."
+    else
+        echo "[-] SHA256 verification failed. Exiting."
+        exit 1
+    fi
+
+    echo "[+] Extracting and installing LND..."
+    tar -xzf "$DOWNLOAD_DIR/lnd-linux-amd64-$LND_VERSION.tar.gz" -C "$DOWNLOAD_DIR" --strip-components=1
+    sudo install -m 0755 -o root -g root "$DOWNLOAD_DIR/lnd" /usr/local/bin/lnd
+    sudo install -m 0755 -o root -g root "$DOWNLOAD_DIR/lncli" /usr/local/bin/lncli
+    rm -rf "$DOWNLOAD_DIR"
+
+    cd "$USER_HOME"
+    echo "[+] LND installed successfully."
+fi
+
+# Set up ~/.lnd directory
+echo "[+] Ensuring ~/.lnd directory exists..."
+if [[ ! -d $LND_DIR ]]; then
+    mkdir -p $LND_DIR
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+else
+    echo "[!] $LND_DIR already exists."
+fi
+
+# Generate wallet password
+echo "[+] Checking for wallet password file..."
+if [[ -f $WALLET_PASSWORD_FILE && -s $WALLET_PASSWORD_FILE ]]; then
+    echo "[+] Wallet password already exists. Skipping."
+else
+    openssl rand -hex 21 > $WALLET_PASSWORD_FILE
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $WALLET_PASSWORD_FILE
+    chmod 600 $WALLET_PASSWORD_FILE
+    echo "[+] Wallet password saved to $WALLET_PASSWORD_FILE."
+fi
+
+# Configure LND
+if [[ -f $LND_CONF_FILE && -s $LND_CONF_FILE ]]; then
+    echo "[+] lnd.conf already exists. Skipping."
+else
+    echo "[+] Configuring LND remote signer with Neutrino backend..."
+
+    # Network
+    while true; do
+        read -p "Which network? [mainnet/signet]: " NETWORK
+        NETWORK=$(echo "$NETWORK" | tr '[:upper:]' '[:lower:]')
+        if [[ "$NETWORK" == "mainnet" || "$NETWORK" == "signet" ]]; then
+            break
+        fi
+        echo "[-] Please enter 'mainnet' or 'signet'."
+    done
+
+    # Mainnet warning
+    if [[ "$NETWORK" == "mainnet" ]]; then
+        echo ""
+        echo "[!] WARNING: Neutrino is not recommended for mainnet production use."
+        echo "    The signer node depends on external peers for block data."
+        echo "    For a production signer, use remote-signer-binary.sh (bitcoind) instead."
+        echo ""
+        read -p "Continue with Neutrino on mainnet anyway? (yes/no): " CONFIRM
+        if [[ "$CONFIRM" != "yes" ]]; then
+            echo "[-] Exiting. Run remote-signer-binary.sh for a production mainnet signer."
+            exit 0
+        fi
+    fi
+
+    read -p "Enter the IP address of this signer node (used by the routing node to connect): " SIGNER_IP
+    if [[ -z $SIGNER_IP ]]; then
+        echo "[-] Signer IP cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter a node alias: " NODE_ALIAS
+
+    # Neutrino peers
+    if [[ "$NETWORK" == "mainnet" ]]; then
+        DEFAULT_PEERS=("${MAINNET_PEERS[@]}")
+        NETWORK_FLAG="bitcoin.mainnet=1"
+        FEE_LINE="neutrino.feeurl=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json"
+    else
+        DEFAULT_PEERS=("${SIGNET_PEERS[@]}")
+        NETWORK_FLAG="bitcoin.signet=1"
+        FEE_LINE=""
+    fi
+
+    PEER_CONFIG=""
+    echo ""
+    echo "[+] Default Neutrino peers for $NETWORK:"
+    for PEER in "${DEFAULT_PEERS[@]}"; do
+        echo "    $PEER"
+        PEER_CONFIG+="neutrino.connect=$PEER"$'\n'
+    done
+
+    read -p "Add additional Neutrino peers? (comma-separated, or press Enter to skip): " EXTRA_PEERS
+    if [[ -n "$EXTRA_PEERS" ]]; then
+        IFS=',' read -ra EXTRA_PEER_ARRAY <<< "$EXTRA_PEERS"
+        for PEER in "${EXTRA_PEER_ARRAY[@]}"; do
+            PEER=$(echo "$PEER" | tr -d '[:space:]')
+            PEER_CONFIG+="neutrino.connect=$PEER"$'\n'
+        done
+    fi
+
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+
+    cat <<EOF > $LND_CONF_FILE
+[Application Options]
+# No p2p — signer should not be internet-exposed
+nolisten=true
+
+# gRPC for routing node to connect
+rpclisten=0.0.0.0:10009
+restlisten=0.0.0.0:8080
+
+# Include signer IP in TLS cert so routing node can verify it
+tlsextraip=$SIGNER_IP
+
+# Auto-unlock wallet on startup
+wallet-unlock-password-file=$WALLET_PASSWORD_FILE
+wallet-unlock-allow-create=true
+
+debuglevel=info
+alias=$NODE_ALIAS
+
+[Bitcoin]
+bitcoin.active=1
+$NETWORK_FLAG
+bitcoin.node=neutrino
+
+[Neutrino]
+${PEER_CONFIG}${FEE_LINE}
+EOF
+
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_CONF_FILE
+    echo "[+] lnd.conf created at $LND_CONF_FILE."
+fi
+
+# Create systemd service (no bitcoind dependency)
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    echo "[+] Creating systemd service for lnd..."
+    LND_PATH=$(which lnd)
+    cat <<EOF > $SERVICE_FILE
+[Unit]
+Description=LND Remote Signer (Neutrino)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=$LND_PATH
+
+User=${SUDO_USER:-$USER}
+Group=${SUDO_USER:-$USER}
+
+Type=simple
+Restart=always
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    echo "[+] Systemd service created."
+else
+    echo "[!] Systemd service already exists. Skipping."
+fi
+
+# Enable and start service
+systemctl enable lnd
+systemctl daemon-reload
+if ! systemctl is-active --quiet lnd; then
+    systemctl start lnd
+    echo "[+] lnd service started."
+else
+    echo "[!] lnd service is already running."
+fi
+
+# Detect network from config
+if grep -q "bitcoin.signet=1" "$LND_CONF_FILE" 2>/dev/null; then
+    NETWORK="signet"
+else
+    NETWORK="mainnet"
+fi
+
+MACAROON_PATH="$LND_DIR/data/chain/bitcoin/$NETWORK/admin.macaroon"
+SEED_FILE="$LND_DIR/seed_phrase.txt"
+XPUB_FILE="$LND_DIR/accounts.json"
+SIGNER_MACAROON="$LND_DIR/signer.macaroon"
+TIMEOUT=180
+
+if [[ -f "$MACAROON_PATH" ]]; then
+    echo "[!] Wallet already initialized. Skipping wallet setup."
+else
+    # Wait for TLS cert
+    echo "[+] Waiting for LND to generate TLS certificate..."
+    ELAPSED=0
+    while [[ ! -f "$LND_DIR/tls.cert" ]]; do
+        sleep 2; ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then echo "[-] Timed out waiting for TLS cert."; exit 1; fi
+    done
+    echo "[+] TLS certificate ready."
+
+    # Wait for REST API
+    echo "[+] Waiting for LND REST API..."
+    ELAPSED=0
+    while ! curl -sf --cacert "$LND_DIR/tls.cert" https://localhost:8080/v1/state > /dev/null 2>&1; do
+        sleep 2; ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then echo "[-] Timed out waiting for REST API."; exit 1; fi
+    done
+    echo "[+] LND REST API ready."
+
+    # Generate seed
+    echo "[+] Generating wallet seed..."
+    SEED_JSON=$(curl -sf --cacert "$LND_DIR/tls.cert" https://localhost:8080/v1/genseed)
+    if [[ -z "$SEED_JSON" ]]; then echo "[-] Failed to generate seed."; exit 1; fi
+
+    MNEMONIC=$(echo "$SEED_JSON" | jq -r '.cipher_seed_mnemonic | join(" ")')
+    MNEMONIC_ARRAY=$(echo "$SEED_JSON" | jq -c '.cipher_seed_mnemonic')
+
+    echo "$MNEMONIC" > "$SEED_FILE"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$SEED_FILE"
+    chmod 600 "$SEED_FILE"
+
+    echo ""
+    echo "============================================================"
+    echo "  !! WALLET SEED PHRASE - BACK THIS UP IMMEDIATELY !!      "
+    echo "  This is your ONLY recovery option if this node is lost.  "
+    echo "============================================================"
+    echo "$MNEMONIC"
+    echo "============================================================"
+    echo "  Saved to: $SEED_FILE  (chmod 600)"
+    echo "  Once backed up, delete it:  shred -u $SEED_FILE"
+    echo "============================================================"
+    echo ""
+
+    # Initialize wallet
+    echo "[+] Initializing wallet..."
+    WALLET_PASSWORD_B64=$(tr -d '\n' < "$WALLET_PASSWORD_FILE" | base64 -w 0)
+    INIT_RESPONSE=$(curl -sf --cacert "$LND_DIR/tls.cert" \
+        -X POST https://localhost:8080/v1/initwallet \
+        -H 'Content-Type: application/json' \
+        -d "{\"wallet_password\": \"$WALLET_PASSWORD_B64\", \"cipher_seed_mnemonic\": $MNEMONIC_ARRAY}")
+
+    if [[ -z "$INIT_RESPONSE" ]]; then echo "[-] No response from initwallet."; exit 1; fi
+    if echo "$INIT_RESPONSE" | jq -e '.code' > /dev/null 2>&1; then
+        echo "[-] Wallet init failed: $(echo "$INIT_RESPONSE" | jq -r '.message')"
+        exit 1
+    fi
+    echo "[+] Wallet initialized, waiting for unlock..."
+
+    ELAPSED=0
+    while [[ ! -f "$MACAROON_PATH" ]]; do
+        sleep 2; ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then echo "[-] Timed out waiting for wallet unlock."; exit 1; fi
+    done
+    echo "[+] Wallet unlocked."
+
+    # Wait for gRPC
+    echo "[+] Waiting for LND gRPC..."
+    ELAPSED=0
+    while ! sudo -u ${SUDO_USER:-$USER} /usr/local/bin/lncli \
+            --network="$NETWORK" \
+            --macaroonpath="$MACAROON_PATH" \
+            --tlscertpath="$LND_DIR/tls.cert" \
+            getinfo > /dev/null 2>&1; do
+        sleep 2; ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then echo "[-] Timed out waiting for gRPC."; exit 1; fi
+    done
+    echo "[+] LND gRPC ready."
+
+    # Export xpubs
+    echo "[+] Exporting account xpubs..."
+    sudo -u ${SUDO_USER:-$USER} /usr/local/bin/lncli \
+        --network="$NETWORK" \
+        --macaroonpath="$MACAROON_PATH" \
+        --tlscertpath="$LND_DIR/tls.cert" \
+        wallet accounts list > "$XPUB_FILE"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$XPUB_FILE"
+    echo "[+] Account xpubs saved to $XPUB_FILE."
+
+    # Bake signing macaroon
+    echo "[+] Baking signing macaroon..."
+    sudo -u ${SUDO_USER:-$USER} /usr/local/bin/lncli \
+        --network="$NETWORK" \
+        --macaroonpath="$MACAROON_PATH" \
+        --tlscertpath="$LND_DIR/tls.cert" \
+        bakemacaroon \
+        signer:generate signer:read signer:write \
+        uri:/walletrpc.WalletKit/DeriveNextKey \
+        uri:/walletrpc.WalletKit/DeriveKey \
+        uri:/walletrpc.WalletKit/SignPsbt \
+        uri:/walletrpc.WalletKit/FinalizePsbt \
+        --save_to "$SIGNER_MACAROON"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$SIGNER_MACAROON"
+    echo "[+] Signing macaroon saved to $SIGNER_MACAROON."
+fi
+
+cat <<"EOF"
+
+[+] LND Remote Signer (Neutrino) setup complete!
+
+Copy these three files to your routing node:
+  ~/.lnd/tls.cert         → rename to signer-tls.cert on routing node
+  ~/.lnd/signer.macaroon
+  ~/.lnd/accounts.json
+
+IMPORTANT: Back up your seed phrase then delete it from disk:
+  shred -u ~/.lnd/seed_phrase.txt
+
+EOF

--- a/skills/run-litd/remote-signer/remote-signer-binary.sh
+++ b/skills/run-litd/remote-signer/remote-signer-binary.sh
@@ -1,0 +1,372 @@
+#!/bin/bash
+
+# LND Remote Signer Setup Script for Ubuntu
+# Assumes bitcoind is already installed and running.
+
+set -e
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LND_DIR="$USER_HOME/.lnd"
+LND_CONF_FILE="$LND_DIR/lnd.conf"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SERVICE_FILE="/etc/systemd/system/lnd.service"
+LND_VERSION="v0.20.1-beta"
+BINARY_URL="https://github.com/lightningnetwork/lnd/releases/download/$LND_VERSION/lnd-linux-amd64-$LND_VERSION.tar.gz"
+MANIFEST_URL="https://github.com/lightningnetwork/lnd/releases/download/$LND_VERSION/manifest-$LND_VERSION.txt"
+SIGNATURE_URL="https://github.com/lightningnetwork/lnd/releases/download/$LND_VERSION/manifest-roasbeef-$LND_VERSION.sig"
+KEY_ID="296212681AADF05656A2CDEE90525F7DEEE0AD86"
+KEY_SERVER="hkps://keyserver.ubuntu.com"
+DOWNLOAD_DIR="/tmp/lnd_release_verification"
+
+# Check if user is root
+echo "[+] Checking for root privileges..."
+if [[ $EUID -ne 0 ]]; then
+  echo "[-] This script must be run as root. Use sudo."
+  exit 1
+fi
+
+# Install dependencies
+echo "[+] Installing dependencies..."
+apt-get update
+apt-get install -y curl jq wget
+
+# Install LND from binary
+echo "[+] Checking if LND is already installed..."
+if [[ -f "/usr/local/bin/lnd" && -f "/usr/local/bin/lncli" ]]; then
+    echo "[+] LND is already installed. Skipping installation."
+else
+    echo "[+] LND not found in /usr/local/bin. Proceeding with installation."
+
+    mkdir -p "$DOWNLOAD_DIR"
+    cd "$DOWNLOAD_DIR" || { echo "[-] Failed to navigate to download directory."; exit 1; }
+
+    echo "[+] Importing LND signing key..."
+    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+
+    echo "[+] Downloading LND binary..."
+    wget "$BINARY_URL" || { echo "[-] Failed to download binary."; exit 1; }
+
+    echo "[+] Downloading manifest..."
+    wget "$MANIFEST_URL" || { echo "[-] Failed to download manifest."; exit 1; }
+
+    echo "[+] Downloading signature..."
+    wget "$SIGNATURE_URL" || { echo "[-] Failed to download signature."; exit 1; }
+
+    echo "[+] Verifying PGP signature..."
+    GPG_OUTPUT=$(gpg --verify "$(basename "$SIGNATURE_URL")" "$(basename "$MANIFEST_URL")" 2>&1 || true)
+    if echo "$GPG_OUTPUT" | grep -q "$KEY_ID"; then
+        echo "[+] Signature verification successful."
+    else
+        echo "[-] Signature verification failed. Exiting."
+        echo "$GPG_OUTPUT"
+        exit 1
+    fi
+
+    echo "[+] Verifying SHA256 checksum..."
+    BINARY_HASH=$(sha256sum "$(basename "$BINARY_URL")" | awk '{print $1}')
+    if grep -q "$BINARY_HASH" "$(basename "$MANIFEST_URL")"; then
+        echo "[+] SHA256 verification successful."
+    else
+        echo "[-] SHA256 verification failed. Exiting."
+        exit 1
+    fi
+
+    echo "[+] Extracting LND binary..."
+    tar -xzf "$DOWNLOAD_DIR/lnd-linux-amd64-$LND_VERSION.tar.gz" -C "$DOWNLOAD_DIR" --strip-components=1
+
+    echo "[+] Installing binaries to /usr/local/bin..."
+    sudo install -m 0755 -o root -g root "$DOWNLOAD_DIR/lnd" /usr/local/bin/lnd
+    sudo install -m 0755 -o root -g root "$DOWNLOAD_DIR/lncli" /usr/local/bin/lncli
+
+    echo "[+] Cleaning up temporary files..."
+    rm -rf "$DOWNLOAD_DIR"
+
+    cd "$USER_HOME"
+    echo "[+] LND installed successfully!"
+fi
+
+# Ensure ~/.lnd directory exists
+echo "[+] Ensuring the ~/.lnd directory exists..."
+if [[ ! -d $LND_DIR ]]; then
+    mkdir -p $LND_DIR
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+    echo "[+] Created directory at $LND_DIR."
+else
+    echo "[!] Directory $LND_DIR already exists."
+fi
+
+# Generate wallet password
+echo "[+] Checking if wallet password file exists..."
+if [[ -f $WALLET_PASSWORD_FILE && -s $WALLET_PASSWORD_FILE ]]; then
+    echo "[+] Wallet password file already exists. Skipping generation."
+else
+    echo "[+] Generating wallet password..."
+    openssl rand -hex 21 > $WALLET_PASSWORD_FILE
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $WALLET_PASSWORD_FILE
+    chmod 600 $WALLET_PASSWORD_FILE
+    echo "[+] Wallet password saved to $WALLET_PASSWORD_FILE."
+fi
+
+# Configure LND
+if [[ -f $LND_CONF_FILE && -s $LND_CONF_FILE ]]; then
+    echo "[+] LND configuration file already exists. Skipping creation."
+else
+    echo "[+] Configuring LND as a remote signer..."
+
+    while true; do
+        read -p "Is your bitcoind backend running on mainnet or signet? [mainnet/signet]: " NETWORK
+        NETWORK=$(echo "$NETWORK" | tr '[:upper:]' '[:lower:]')
+        if [[ "$NETWORK" == "mainnet" || "$NETWORK" == "signet" ]]; then
+            break
+        else
+            echo "[-] Invalid input. Please enter 'mainnet' or 'signet'."
+        fi
+    done
+
+    read -s -p "Enter the RPC password for your bitcoind backend: " RPC_PASSWORD
+    echo
+    if [[ -z $RPC_PASSWORD ]]; then
+        echo "[-] RPC password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter the IP address of this remote signer node (used by the watch-only node to connect): " SIGNER_IP
+    if [[ -z $SIGNER_IP ]]; then
+        echo "[-] Signer IP cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter a node alias: " NODE_ALIAS
+
+    cat <<EOF > $LND_CONF_FILE
+[Application Options]
+# Do not listen for p2p connections - remote signers don't need them
+nolisten=true
+
+# Listen for gRPC connections from the watch-only node
+rpclisten=0.0.0.0:10009
+restlisten=0.0.0.0:8080
+
+# Include this node's IP in the TLS certificate so the watch-only node can verify it
+tlsextraip=$SIGNER_IP
+
+# Auto-unlock wallet on startup
+wallet-unlock-password-file=$WALLET_PASSWORD_FILE
+wallet-unlock-allow-create=true
+
+debuglevel=info
+alias=$NODE_ALIAS
+
+[Bitcoin]
+bitcoin.active=1
+$( [[ "$NETWORK" == "signet" ]] && echo "bitcoin.signet=1" || echo "bitcoin.mainnet=1" )
+bitcoin.node=bitcoind
+
+[Bitcoind]
+bitcoind.rpchost=127.0.0.1
+bitcoind.rpcuser=bitcoinrpc
+bitcoind.rpcpass=$RPC_PASSWORD
+bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+EOF
+
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_CONF_FILE
+    echo "[+] LND configuration file created at $LND_CONF_FILE."
+fi
+
+# Create systemd service file
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    echo "[+] Creating systemd service file for lnd..."
+    LND_PATH=$(which lnd)
+    cat <<EOF > $SERVICE_FILE
+[Unit]
+Description=LND Remote Signer
+Requires=bitcoind.service
+After=bitcoind.service
+
+[Service]
+ExecStart=$LND_PATH
+
+User=${SUDO_USER:-$USER}
+Group=${SUDO_USER:-$USER}
+
+Type=simple
+Restart=always
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    echo "[+] Systemd service file created at $SERVICE_FILE."
+else
+    echo "[!] Systemd service file already exists. Skipping creation."
+fi
+
+# Enable and start the service
+systemctl enable lnd
+systemctl daemon-reload
+if ! systemctl is-active --quiet lnd; then
+    systemctl start lnd
+    echo "[+] lnd service started."
+else
+    echo "[!] lnd service is already running."
+fi
+
+# Detect network from config
+if grep -q "bitcoin.signet=1" "$LND_CONF_FILE" 2>/dev/null; then
+    NETWORK="signet"
+else
+    NETWORK="mainnet"
+fi
+
+MACAROON_PATH="$LND_DIR/data/chain/bitcoin/$NETWORK/admin.macaroon"
+SEED_FILE="$LND_DIR/seed_phrase.txt"
+XPUB_FILE="$LND_DIR/accounts.json"
+SIGNER_MACAROON="$LND_DIR/signer.macaroon"
+TIMEOUT=180
+
+if [[ -f "$MACAROON_PATH" ]]; then
+    echo "[!] Wallet already initialized. Skipping wallet setup."
+else
+    # Wait for TLS cert
+    echo "[+] Waiting for LND to generate TLS certificate..."
+    ELAPSED=0
+    while [[ ! -f "$LND_DIR/tls.cert" ]]; do
+        sleep 2
+        ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then
+            echo "[-] Timed out waiting for TLS certificate. Exiting."
+            exit 1
+        fi
+    done
+    echo "[+] TLS certificate ready."
+
+    # Wait for REST API
+    echo "[+] Waiting for LND REST API..."
+    ELAPSED=0
+    while ! curl -sf --cacert "$LND_DIR/tls.cert" https://localhost:8080/v1/state > /dev/null 2>&1; do
+        sleep 2
+        ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then
+            echo "[-] Timed out waiting for LND REST API. Exiting."
+            exit 1
+        fi
+    done
+    echo "[+] LND REST API is ready."
+
+    # Generate seed
+    echo "[+] Generating wallet seed..."
+    SEED_JSON=$(curl -sf --cacert "$LND_DIR/tls.cert" https://localhost:8080/v1/genseed)
+    if [[ -z "$SEED_JSON" ]]; then
+        echo "[-] Failed to generate seed. Exiting."
+        exit 1
+    fi
+
+    MNEMONIC=$(echo "$SEED_JSON" | jq -r '.cipher_seed_mnemonic | join(" ")')
+    MNEMONIC_ARRAY=$(echo "$SEED_JSON" | jq -c '.cipher_seed_mnemonic')
+
+    # Save seed to file (chmod 600 - readable only by owner)
+    echo "$MNEMONIC" > "$SEED_FILE"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$SEED_FILE"
+    chmod 600 "$SEED_FILE"
+
+    echo ""
+    echo "============================================================"
+    echo "  !! WALLET SEED PHRASE - BACK THIS UP IMMEDIATELY !!      "
+    echo "  This is your ONLY recovery option if this node is lost.  "
+    echo "============================================================"
+    echo "$MNEMONIC"
+    echo "============================================================"
+    echo "  Saved to: $SEED_FILE  (chmod 600)"
+    echo "  Once backed up, delete it:  shred -u $SEED_FILE"
+    echo "============================================================"
+    echo ""
+
+    # Initialize wallet
+    echo "[+] Initializing wallet..."
+    WALLET_PASSWORD_B64=$(tr -d '\n' < "$WALLET_PASSWORD_FILE" | base64 -w 0)
+    INIT_RESPONSE=$(curl -sf --cacert "$LND_DIR/tls.cert" \
+        -X POST https://localhost:8080/v1/initwallet \
+        -H 'Content-Type: application/json' \
+        -d "{\"wallet_password\": \"$WALLET_PASSWORD_B64\", \"cipher_seed_mnemonic\": $MNEMONIC_ARRAY}")
+
+    if [[ -z "$INIT_RESPONSE" ]]; then
+        echo "[-] No response from initwallet endpoint. Exiting."
+        exit 1
+    fi
+    if echo "$INIT_RESPONSE" | jq -e '.code' > /dev/null 2>&1; then
+        echo "[-] Failed to initialize wallet: $(echo "$INIT_RESPONSE" | jq -r '.message')"
+        exit 1
+    fi
+    echo "[+] Wallet initialized, waiting for unlock..."
+
+    # Wait for admin macaroon (signals wallet is fully unlocked)
+    ELAPSED=0
+    while [[ ! -f "$MACAROON_PATH" ]]; do
+        sleep 2
+        ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then
+            echo "[-] Timed out waiting for wallet to unlock. Exiting."
+            exit 1
+        fi
+    done
+    echo "[+] Wallet unlocked."
+
+    # Wait for gRPC server to be fully ready
+    echo "[+] Waiting for LND gRPC to be ready..."
+    ELAPSED=0
+    while ! sudo -u ${SUDO_USER:-$USER} /usr/local/bin/lncli \
+            --network="$NETWORK" \
+            --macaroonpath="$MACAROON_PATH" \
+            --tlscertpath="$LND_DIR/tls.cert" \
+            getinfo > /dev/null 2>&1; do
+        sleep 2
+        ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then
+            echo "[-] Timed out waiting for LND gRPC. Exiting."
+            exit 1
+        fi
+    done
+    echo "[+] LND gRPC is ready."
+
+    # Export xpub
+    echo "[+] Exporting account xpub..."
+    sudo -u ${SUDO_USER:-$USER} /usr/local/bin/lncli \
+        --network="$NETWORK" \
+        --macaroonpath="$MACAROON_PATH" \
+        --tlscertpath="$LND_DIR/tls.cert" \
+        wallet accounts list > "$XPUB_FILE"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$XPUB_FILE"
+    echo "[+] Account xpub saved to $XPUB_FILE"
+
+    # Bake signing macaroon for the watch-only node
+    echo "[+] Baking signing macaroon for watch-only node..."
+    sudo -u ${SUDO_USER:-$USER} /usr/local/bin/lncli \
+        --network="$NETWORK" \
+        --macaroonpath="$MACAROON_PATH" \
+        --tlscertpath="$LND_DIR/tls.cert" \
+        bakemacaroon \
+        signer:generate signer:read signer:write \
+        uri:/walletrpc.WalletKit/DeriveNextKey \
+        uri:/walletrpc.WalletKit/DeriveKey \
+        uri:/walletrpc.WalletKit/SignPsbt \
+        uri:/walletrpc.WalletKit/FinalizePsbt \
+        --save_to "$SIGNER_MACAROON"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$SIGNER_MACAROON"
+    echo "[+] Signing macaroon saved to $SIGNER_MACAROON"
+fi
+
+cat <<"EOF"
+
+[+] LND Remote Signer setup complete!
+
+Copy these files to your watch-only node:
+  - TLS certificate:   ~/.lnd/tls.cert
+  - Signing macaroon:  ~/.lnd/signer.macaroon
+  - Account xpub:      ~/.lnd/accounts.json
+
+IMPORTANT: Back up your seed phrase and then delete it from disk:
+  shred -u ~/.lnd/seed_phrase.txt
+
+EOF

--- a/skills/run-litd/remote-signer/remote-signer.sh
+++ b/skills/run-litd/remote-signer/remote-signer.sh
@@ -1,0 +1,394 @@
+#!/bin/bash
+
+# LND Remote Signer Setup Script for Ubuntu (build from source)
+# Assumes bitcoind is already installed and running.
+
+set -e
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LND_DIR="$USER_HOME/.lnd"
+LND_CONF_FILE="$LND_DIR/lnd.conf"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SERVICE_FILE="/etc/systemd/system/lnd.service"
+LND_VERSION="v0.20.1-beta"
+GO_VERSION="1.23.9"
+
+# Check if user is root
+echo "[+] Checking for root privileges..."
+if [[ $EUID -ne 0 ]]; then
+  echo "[-] This script must be run as root. Use sudo."
+  exit 1
+fi
+
+# Update & Install dependencies
+echo "[+] Updating system and installing dependencies..."
+apt-get update && apt-get upgrade -y
+apt-get install -y git build-essential curl jq
+
+# Install Go
+echo "[+] Checking if Go $GO_VERSION is installed..."
+if command -v go &> /dev/null && [[ $(go version | awk '{print $3}' | cut -c3-) == "$GO_VERSION" ]]; then
+    echo "[+] Go $GO_VERSION is already installed. Skipping installation."
+else
+    echo "[+] Installing Go $GO_VERSION..."
+    wget "https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz" -O go.tar.gz
+    if [[ -f go.tar.gz ]]; then
+        sudo tar -C /usr/local -xzf go.tar.gz
+        rm go.tar.gz
+
+        sudo -u ${SUDO_USER:-$USER} bash -c "
+        if ! grep -q 'export GOPATH=$USER_HOME/go' $USER_HOME/.profile; then
+            echo 'export GOPATH=$USER_HOME/go' >> $USER_HOME/.profile
+        fi
+        if ! grep -q 'export PATH=$USER_HOME/go/bin:/usr/local/go/bin:\$PATH' $USER_HOME/.profile; then
+            echo 'export PATH=$USER_HOME/go/bin:/usr/local/go/bin:\$PATH' >> $USER_HOME/.profile
+        fi
+        "
+
+        export GOPATH="$USER_HOME/go"
+        export PATH="$USER_HOME/go/bin:/usr/local/go/bin:$PATH"
+
+        echo "[+] Go $GO_VERSION installed successfully."
+    else
+        echo "[-] Failed to download Go tarball. Exiting."
+        exit 1
+    fi
+fi
+
+# Ensure go bin dir exists
+if [[ ! -d "$USER_HOME/go/bin" ]]; then
+    mkdir -p "$USER_HOME/go/bin"
+fi
+sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/go"
+
+# Clone and build LND
+echo "[+] Checking if LND is already installed..."
+if [[ -f "$USER_HOME/go/bin/lnd" ]]; then
+    echo "[+] LND is already installed. Skipping build."
+else
+    echo "[+] Checking for LND repository..."
+    if [[ -d "$USER_HOME/lnd" ]]; then
+        echo "[!] Repository already exists. Using existing directory."
+        cd "$USER_HOME/lnd"
+    else
+        echo "[+] Cloning LND repository into $USER_HOME/lnd..."
+        if git clone https://github.com/lightningnetwork/lnd.git "$USER_HOME/lnd"; then
+            echo "[+] Repository cloned successfully."
+            cd "$USER_HOME/lnd"
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/lnd"
+        else
+            echo "[-] Failed to clone repository. Exiting."
+            exit 1
+        fi
+    fi
+
+    echo "[+] Checking out version $LND_VERSION..."
+    if git checkout tags/$LND_VERSION; then
+        echo "[+] Building LND... This may take a few minutes."
+        export GOPATH=$USER_HOME/go
+        export PATH=$USER_HOME/go/bin:/usr/local/go/bin:$PATH
+        if make install tags="walletrpc signrpc routerrpc chainrpc invoicesrpc"; then
+            echo "[+] LND built and installed successfully."
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/go"
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/lnd"
+        else
+            echo "[-] Failed to build LND. Exiting."
+            exit 1
+        fi
+    else
+        echo "[-] Failed to checkout version $LND_VERSION. Exiting."
+        exit 1
+    fi
+fi
+
+# Ensure ~/.lnd directory exists
+echo "[+] Ensuring the ~/.lnd directory exists..."
+if [[ ! -d $LND_DIR ]]; then
+    mkdir -p $LND_DIR
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+    echo "[+] Created directory at $LND_DIR."
+else
+    echo "[!] Directory $LND_DIR already exists."
+fi
+
+# Generate wallet password
+echo "[+] Checking if wallet password file exists..."
+if [[ -f $WALLET_PASSWORD_FILE && -s $WALLET_PASSWORD_FILE ]]; then
+    echo "[+] Wallet password file already exists. Skipping generation."
+else
+    echo "[+] Generating wallet password..."
+    openssl rand -hex 21 > $WALLET_PASSWORD_FILE
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $WALLET_PASSWORD_FILE
+    chmod 600 $WALLET_PASSWORD_FILE
+    echo "[+] Wallet password saved to $WALLET_PASSWORD_FILE."
+fi
+
+# Configure LND
+if [[ -f $LND_CONF_FILE && -s $LND_CONF_FILE ]]; then
+    echo "[+] LND configuration file already exists. Skipping creation."
+else
+    echo "[+] Configuring LND as a remote signer..."
+
+    while true; do
+        read -p "Is your bitcoind backend running on mainnet or signet? [mainnet/signet]: " NETWORK
+        NETWORK=$(echo "$NETWORK" | tr '[:upper:]' '[:lower:]')
+        if [[ "$NETWORK" == "mainnet" || "$NETWORK" == "signet" ]]; then
+            break
+        else
+            echo "[-] Invalid input. Please enter 'mainnet' or 'signet'."
+        fi
+    done
+
+    read -s -p "Enter the RPC password for your bitcoind backend: " RPC_PASSWORD
+    echo
+    if [[ -z $RPC_PASSWORD ]]; then
+        echo "[-] RPC password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter the IP address of this remote signer node (used by the watch-only node to connect): " SIGNER_IP
+    if [[ -z $SIGNER_IP ]]; then
+        echo "[-] Signer IP cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter a node alias: " NODE_ALIAS
+
+    cat <<EOF > $LND_CONF_FILE
+[Application Options]
+# Do not listen for p2p connections - remote signers don't need them
+nolisten=true
+
+# Listen for gRPC connections from the watch-only node
+rpclisten=0.0.0.0:10009
+restlisten=0.0.0.0:8080
+
+# Include this node's IP in the TLS certificate so the watch-only node can verify it
+tlsextraip=$SIGNER_IP
+
+# Auto-unlock wallet on startup
+wallet-unlock-password-file=$WALLET_PASSWORD_FILE
+wallet-unlock-allow-create=true
+
+debuglevel=info
+alias=$NODE_ALIAS
+
+[Bitcoin]
+bitcoin.active=1
+$( [[ "$NETWORK" == "signet" ]] && echo "bitcoin.signet=1" || echo "bitcoin.mainnet=1" )
+bitcoin.node=bitcoind
+
+[Bitcoind]
+bitcoind.rpchost=127.0.0.1
+bitcoind.rpcuser=bitcoinrpc
+bitcoind.rpcpass=$RPC_PASSWORD
+bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+EOF
+
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_CONF_FILE
+    echo "[+] LND configuration file created at $LND_CONF_FILE."
+fi
+
+# Create systemd service file
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    echo "[+] Creating systemd service file for lnd..."
+    LND_PATH="$USER_HOME/go/bin/lnd"
+    cat <<EOF > $SERVICE_FILE
+[Unit]
+Description=LND Remote Signer
+Requires=bitcoind.service
+After=bitcoind.service
+
+[Service]
+ExecStart=$LND_PATH
+
+User=${SUDO_USER:-$USER}
+Group=${SUDO_USER:-$USER}
+
+Type=simple
+Restart=always
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    echo "[+] Systemd service file created at $SERVICE_FILE."
+else
+    echo "[!] Systemd service file already exists. Skipping creation."
+fi
+
+# Enable and start the service
+systemctl enable lnd
+systemctl daemon-reload
+if ! systemctl is-active --quiet lnd; then
+    systemctl start lnd
+    echo "[+] lnd service started."
+else
+    echo "[!] lnd service is already running."
+fi
+
+# Detect network from config
+if grep -q "bitcoin.signet=1" "$LND_CONF_FILE" 2>/dev/null; then
+    NETWORK="signet"
+else
+    NETWORK="mainnet"
+fi
+
+MACAROON_PATH="$LND_DIR/data/chain/bitcoin/$NETWORK/admin.macaroon"
+LNCLI="$USER_HOME/go/bin/lncli"
+SEED_FILE="$LND_DIR/seed_phrase.txt"
+XPUB_FILE="$LND_DIR/accounts.json"
+SIGNER_MACAROON="$LND_DIR/signer.macaroon"
+TIMEOUT=180
+
+if [[ -f "$MACAROON_PATH" ]]; then
+    echo "[!] Wallet already initialized. Skipping wallet setup."
+else
+    # Wait for TLS cert
+    echo "[+] Waiting for LND to generate TLS certificate..."
+    ELAPSED=0
+    while [[ ! -f "$LND_DIR/tls.cert" ]]; do
+        sleep 2
+        ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then
+            echo "[-] Timed out waiting for TLS certificate. Exiting."
+            exit 1
+        fi
+    done
+    echo "[+] TLS certificate ready."
+
+    # Wait for REST API
+    echo "[+] Waiting for LND REST API..."
+    ELAPSED=0
+    while ! curl -sf --cacert "$LND_DIR/tls.cert" https://localhost:8080/v1/state > /dev/null 2>&1; do
+        sleep 2
+        ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then
+            echo "[-] Timed out waiting for LND REST API. Exiting."
+            exit 1
+        fi
+    done
+    echo "[+] LND REST API is ready."
+
+    # Generate seed
+    echo "[+] Generating wallet seed..."
+    SEED_JSON=$(curl -sf --cacert "$LND_DIR/tls.cert" https://localhost:8080/v1/genseed)
+    if [[ -z "$SEED_JSON" ]]; then
+        echo "[-] Failed to generate seed. Exiting."
+        exit 1
+    fi
+
+    MNEMONIC=$(echo "$SEED_JSON" | jq -r '.cipher_seed_mnemonic | join(" ")')
+    MNEMONIC_ARRAY=$(echo "$SEED_JSON" | jq -c '.cipher_seed_mnemonic')
+
+    # Save seed to file (chmod 600 - readable only by owner)
+    echo "$MNEMONIC" > "$SEED_FILE"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$SEED_FILE"
+    chmod 600 "$SEED_FILE"
+
+    echo ""
+    echo "============================================================"
+    echo "  !! WALLET SEED PHRASE - BACK THIS UP IMMEDIATELY !!      "
+    echo "  This is your ONLY recovery option if this node is lost.  "
+    echo "============================================================"
+    echo "$MNEMONIC"
+    echo "============================================================"
+    echo "  Saved to: $SEED_FILE  (chmod 600)"
+    echo "  Once backed up, delete it:  shred -u $SEED_FILE"
+    echo "============================================================"
+    echo ""
+
+    # Initialize wallet
+    echo "[+] Initializing wallet..."
+    WALLET_PASSWORD_B64=$(tr -d '\n' < "$WALLET_PASSWORD_FILE" | base64 -w 0)
+    INIT_RESPONSE=$(curl -sf --cacert "$LND_DIR/tls.cert" \
+        -X POST https://localhost:8080/v1/initwallet \
+        -H 'Content-Type: application/json' \
+        -d "{\"wallet_password\": \"$WALLET_PASSWORD_B64\", \"cipher_seed_mnemonic\": $MNEMONIC_ARRAY}")
+
+    if [[ -z "$INIT_RESPONSE" ]]; then
+        echo "[-] No response from initwallet endpoint. Exiting."
+        exit 1
+    fi
+    if echo "$INIT_RESPONSE" | jq -e '.code' > /dev/null 2>&1; then
+        echo "[-] Failed to initialize wallet: $(echo "$INIT_RESPONSE" | jq -r '.message')"
+        exit 1
+    fi
+    echo "[+] Wallet initialized, waiting for unlock..."
+
+    # Wait for admin macaroon (signals wallet is fully unlocked)
+    ELAPSED=0
+    while [[ ! -f "$MACAROON_PATH" ]]; do
+        sleep 2
+        ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then
+            echo "[-] Timed out waiting for wallet to unlock. Exiting."
+            exit 1
+        fi
+    done
+    echo "[+] Wallet unlocked."
+
+    # Wait for gRPC server to be fully ready
+    echo "[+] Waiting for LND gRPC to be ready..."
+    ELAPSED=0
+    while ! sudo -u ${SUDO_USER:-$USER} "$LNCLI" \
+            --network="$NETWORK" \
+            --macaroonpath="$MACAROON_PATH" \
+            --tlscertpath="$LND_DIR/tls.cert" \
+            getinfo > /dev/null 2>&1; do
+        sleep 2
+        ELAPSED=$((ELAPSED + 2))
+        if [[ $ELAPSED -ge $TIMEOUT ]]; then
+            echo "[-] Timed out waiting for LND gRPC. Exiting."
+            exit 1
+        fi
+    done
+    echo "[+] LND gRPC is ready."
+
+    # Export xpub
+    echo "[+] Exporting account xpub..."
+    sudo -u ${SUDO_USER:-$USER} "$LNCLI" \
+        --network="$NETWORK" \
+        --macaroonpath="$MACAROON_PATH" \
+        --tlscertpath="$LND_DIR/tls.cert" \
+        wallet accounts list > "$XPUB_FILE"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$XPUB_FILE"
+    echo "[+] Account xpub saved to $XPUB_FILE"
+
+    # Bake signing macaroon for the watch-only node
+    echo "[+] Baking signing macaroon for watch-only node..."
+    sudo -u ${SUDO_USER:-$USER} "$LNCLI" \
+        --network="$NETWORK" \
+        --macaroonpath="$MACAROON_PATH" \
+        --tlscertpath="$LND_DIR/tls.cert" \
+        bakemacaroon \
+        signer:generate signer:read signer:write \
+        uri:/walletrpc.WalletKit/DeriveNextKey \
+        uri:/walletrpc.WalletKit/DeriveKey \
+        uri:/walletrpc.WalletKit/SignPsbt \
+        uri:/walletrpc.WalletKit/FinalizePsbt \
+        --save_to "$SIGNER_MACAROON"
+    chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$SIGNER_MACAROON"
+    echo "[+] Signing macaroon saved to $SIGNER_MACAROON"
+fi
+
+cat <<"EOF"
+
+[+] LND Remote Signer setup complete!
+
+Copy these files to your watch-only node:
+  - TLS certificate:   ~/.lnd/tls.cert
+  - Signing macaroon:  ~/.lnd/signer.macaroon
+  - Account xpub:      ~/.lnd/accounts.json
+
+IMPORTANT: Back up your seed phrase and then delete it from disk:
+  shred -u ~/.lnd/seed_phrase.txt
+
+NOTE: To use lncli in this terminal session, run:
+  source ~/.profile
+Then you can run commands such as:
+  lncli --network=<mainnet|signet> getinfo
+
+EOF

--- a/skills/run-litd/remote-signer/routing-node-binary.sh
+++ b/skills/run-litd/remote-signer/routing-node-binary.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+
+# litd Routing Node Setup Script for Ubuntu (Binary Install)
+# Configures litd as a watch-only routing node backed by a remote signer.
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_CONF_DIR="$USER_HOME/.lit"
+LIT_CONF_FILE="$LIT_CONF_DIR/lit.conf"
+LND_DIR="$USER_HOME/.lnd"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SIGNER_TLS_CERT="$LND_DIR/signer-tls.cert"
+SIGNER_MACAROON="$LND_DIR/signer.macaroon"
+SIGNER_ACCOUNTS="$LND_DIR/accounts.json"
+SERVICE_FILE="/etc/systemd/system/litd.service"
+
+LITD_VERSION="v0.16.1-alpha"  # Version of litd to be installed
+BINARY_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/lightning-terminal-linux-amd64-$LITD_VERSION.tar.gz"
+SIGNATURE_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/manifest-ellemouton-$LITD_VERSION.sig"
+MANIFEST_URL="https://github.com/lightninglabs/lightning-terminal/releases/download/$LITD_VERSION/manifest-$LITD_VERSION.txt"
+KEY_ID="26984CB69EB8C4A26196F7A4D7D916376026F177"
+KEY_SERVER="hkps://keyserver.ubuntu.com"
+DOWNLOAD_DIR="/tmp/litd_release_verification"
+
+
+# Install litd from binary
+echo "[+] Checking if Lightning Terminal is already installed..."
+if [[ -f "/usr/local/bin/litd" ]]; then
+    echo "[+] Lightning Terminal (litd) is already installed. Skipping installation."
+else
+    echo "[+] litd not found in /usr/local/bin. Proceeding with installation."
+
+    # Create download directory
+    mkdir -p "$DOWNLOAD_DIR"
+    cd "$DOWNLOAD_DIR" || { echo "Failed to navigate to download directory."; exit 1; }
+    echo "The current working directory is: $PWD"
+
+    # Import Signing key
+    echo "Importing Signing key..."
+    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "Failed to import PGP key."; exit 1; }
+
+    # Download litd binary
+    echo "Downloading binary..."
+    wget "$BINARY_URL" || { echo "Failed to download binary."; exit 1; }
+
+    echo "Downloading signature..."
+    wget "$SIGNATURE_URL" || { echo "Failed to download signature."; exit 1; }
+
+    echo "Downloading manifest..."
+    wget "$MANIFEST_URL" || { echo "Failed to download manifest."; exit 1; }
+
+    # Verify the release signature
+    echo "Verifying signature..."
+    GPG_OUTPUT=$(gpg --verify "$(basename "$SIGNATURE_URL")" "$(basename "$MANIFEST_URL")" 2>&1 || true)
+    if echo "$GPG_OUTPUT" | grep -q "$KEY_ID"; then
+        echo "Signature verification successful."
+    else
+        echo "Signature verification failed or does not match the expected key ID: $KEY_ID."
+        echo "$GPG_OUTPUT"
+        exit 1
+    fi
+
+    #Check SHASUM
+    echo "Checking shasum..."
+    grep "$(sha256sum "$(basename "$BINARY_URL")" | awk '{print $1}')" "$(basename "$MANIFEST_URL")" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "SHA256 hash verification successful."
+    else
+        echo "SHA256 hash verification failed."
+        exit 1
+    fi
+
+    echo "[+] Extracting litd binary..."
+    tar -xvzf "$DOWNLOAD_DIR/lightning-terminal-linux-amd64-$LITD_VERSION.tar.gz" -C "$DOWNLOAD_DIR" --strip-components=1
+
+    echo "[+] Installing binaries to /usr/local/bin..."
+    find "$DOWNLOAD_DIR" -maxdepth 1 -type f -executable -exec sudo install -m 0755 -o root -g root {} /usr/local/bin/ \;
+
+    echo "[+] Cleaning up temporary files..."
+    rm -rf "$DOWNLOAD_DIR"
+
+    echo "[+] litd successfully installed!"
+
+    # Change back to the ubuntu user's home directory
+    cd "$USER_HOME" || { echo "Failed to return to the user's home directory: $USER_HOME"; exit 1; }
+fi
+
+# Ensure ~/.lnd directory exists
+echo "[+] Ensuring the ~/.lnd directory exists..."
+if [[ ! -d $LND_DIR ]]; then
+    mkdir -p $LND_DIR
+    echo "[+] Created directory at $LND_DIR."
+    # Ensure ~/.lnd directory is owned by the user
+    echo "[+] Ensuring ownership of $LND_DIR..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LND_DIR."
+else
+    echo "[!] Directory $LND_DIR already exists."
+fi
+
+# Generate wallet password
+echo "[+] Checking if wallet password file exists and is not empty..."
+if [[ -f $WALLET_PASSWORD_FILE && -s $WALLET_PASSWORD_FILE ]]; then
+    echo "[+] Wallet password file already exists and is not empty. Skipping generation."
+else
+    echo "[+] Generating wallet password..."
+    openssl rand -hex 21 > $WALLET_PASSWORD_FILE
+    chmod 600 $WALLET_PASSWORD_FILE
+    if [[ -f $WALLET_PASSWORD_FILE ]]; then
+        echo "[+] Wallet password generated and saved to $WALLET_PASSWORD_FILE."
+        # Ensure wallet password file is owned by the user
+        echo "[+] Ensuring ownership of $WALLET_PASSWORD_FILE..."
+        sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $WALLET_PASSWORD_FILE
+        echo "[+] Ownership set to ${SUDO_USER:-$USER} for $WALLET_PASSWORD_FILE."
+    else
+        echo "[-] Failed to generate wallet password. Exiting."
+        exit 1
+    fi
+fi
+
+# Check for required signer files
+echo "[+] Checking for required signer files..."
+MISSING_FILES=0
+for FILE in "$SIGNER_TLS_CERT" "$SIGNER_MACAROON" "$SIGNER_ACCOUNTS"; do
+    if [[ ! -f "$FILE" ]]; then
+        echo "[-] Missing required signer file: $FILE"
+        MISSING_FILES=1
+    fi
+done
+if [[ $MISSING_FILES -eq 1 ]]; then
+    echo "[-] One or more required signer files are missing."
+    echo "    Copy the following files from your signer node to this server, then re-run this script."
+    echo "    Note: the signer's tls.cert must be renamed to signer-tls.cert to avoid conflict with"
+    echo "    the routing node's own tls.cert."
+    echo ""
+    echo "    scp user@<signer-ip>:~/.lnd/tls.cert        $SIGNER_TLS_CERT"
+    echo "    scp user@<signer-ip>:~/.lnd/signer.macaroon $SIGNER_MACAROON"
+    echo "    scp user@<signer-ip>:~/.lnd/accounts.json   $SIGNER_ACCOUNTS"
+    echo ""
+    echo "    Once copied, re-run this script to continue. All completed steps will be skipped."
+    exit 1
+fi
+echo "[+] All required signer files found."
+
+# Configure litd
+echo "[+] Step 4: Configuring Lightning Terminal (litd)..."
+
+# Check if configuration directory exists
+if [[ ! -d $LIT_CONF_DIR ]]; then
+    mkdir -p $LIT_CONF_DIR
+    echo "[+] Created configuration directory at $LIT_CONF_DIR."
+    # Ensure .lit directory is owned by the user
+    echo "[+] Ensuring ownership of $LIT_CONF_DIR..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_DIR
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LIT_CONF_DIR."
+else
+    echo "[!] $LIT_CONF_DIR already exists."
+fi
+
+# Check if configuration file exists and is not empty
+if [[ -f $LIT_CONF_FILE && -s $LIT_CONF_FILE ]]; then
+    echo "[+] Configuration file already exists and is not empty. Skipping creation."
+else
+    echo "[+] Generating new configuration file..."
+
+    read -p "Is your bitcoind backend running on mainnet or signet? [mainnet/signet]: " NETWORK
+    NETWORK=$(echo "$NETWORK" | tr '[:upper:]' '[:lower:]')
+    if [[ $NETWORK != "mainnet" && $NETWORK != "signet" ]]; then
+        echo "[-] Invalid network selection. Please choose either 'mainnet' or 'signet'."
+        exit 1
+    fi
+
+    read -s -p "Enter the RPC password for your bitcoind backend: " RPC_PASSWORD
+    echo
+    if [[ -z $RPC_PASSWORD ]]; then
+        echo "[-] RPC password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -s -p "Enter a UI password for litd: " UI_PASSWORD
+    echo
+    if [[ -z $UI_PASSWORD ]]; then
+        echo "[-] UI password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter a Lightning Node alias: " NODE_ALIAS
+
+    read -p "Enter the remote signer's IP address or hostname: " SIGNER_IP
+    if [[ -z $SIGNER_IP ]]; then
+        echo "[-] Signer IP cannot be empty. Exiting."
+        exit 1
+    fi
+
+    # Prepare the base configuration content
+    CONFIG_CONTENT="# Litd Settings
+enablerest=true
+httpslisten=0.0.0.0:8443
+uipassword=$UI_PASSWORD
+network=$NETWORK
+lnd-mode=integrated
+pool-mode=disable
+loop-mode=disable
+autopilot.disable=true
+
+# Bitcoin Configuration
+lnd.bitcoin.active=1
+lnd.bitcoin.node=bitcoind
+lnd.bitcoind.rpchost=127.0.0.1
+lnd.bitcoind.rpcuser=bitcoinrpc
+lnd.bitcoind.rpcpass=$RPC_PASSWORD
+lnd.bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+lnd.bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+
+# LND General Settings
+#lnd.wallet-unlock-password-file=/home/ubuntu/.lnd/wallet_password
+#lnd.wallet-unlock-allow-create=true
+lnd.debuglevel=debug
+lnd.alias=$NODE_ALIAS
+lnd.maxpendingchannels=3
+lnd.accept-keysend=true
+lnd.accept-amp=true
+lnd.rpcmiddleware.enable=true
+lnd.autopilot.active=0
+
+# LND Protocol Settings
+lnd.protocol.simple-taproot-chans=true
+lnd.protocol.simple-taproot-overlay-chans=true
+lnd.protocol.option-scid-alias=true
+lnd.protocol.zero-conf=true
+lnd.protocol.custom-message=17
+
+# Remote Signer Settings
+lnd.remotesigner.enable=true
+lnd.remotesigner.rpchost=$SIGNER_IP:10009
+lnd.remotesigner.tlscertpath=$SIGNER_TLS_CERT
+lnd.remotesigner.macaroonpath=$SIGNER_MACAROON
+
+# Taproot Assets Settings
+#taproot-assets.rpclisten=0.0.0.0:10029
+#taproot-assets.allow-public-uni-proof-courier=true
+#taproot-assets.allow-public-stats=true
+#taproot-assets.universe.public-access=rw
+#taproot-assets.experimental.rfq.skipacceptquotepricecheck=true
+#taproot-assets.experimental.rfq.priceoracleaddress=rfqrpc://127.0.0.1:8095
+#taproot-assets.experimental.rfq.priceoracleaddress=use_mock_price_oracle_service_promise_to_not_use_on_mainnet
+#taproot-assets.experimental.rfq.mockoracleassetsperbtc=100000000"
+
+    # Apply mainnet-specific logic
+    if [[ $NETWORK == "mainnet" ]]; then
+        CONFIG_CONTENT=$(echo "$CONFIG_CONTENT" | sed "/pool-mode=disable/s/^/# /" | sed "/loop-mode=disable/s/^/# /" | sed "/autopilot.disable=true/s/^/# /")
+    fi
+
+    # Write configuration content to file
+    echo "$CONFIG_CONTENT" > $LIT_CONF_FILE
+    echo "[+] Configuration file created at $LIT_CONF_FILE."
+
+    # Ensure configuration file is owned by the user
+    echo "[+] Ensuring ownership of $LIT_CONF_FILE..."
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_FILE
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LIT_CONF_FILE."
+fi
+
+echo "Now you have a task! Start litd with $ litd, do so as the user who will be running litd."
+echo "In a new tab..."
+echo "Initialize the watch-only wallet using:"
+echo "  $ lncli --network=[yournetwork] createwatchonly ~/.lnd/accounts.json"
+echo "Use the already generated password which can be found via $ cat ~/.lnd/wallet_password"
+echo "Then, stop litd, and run the next script... almost there!!!"

--- a/skills/run-litd/remote-signer/routing-node.sh
+++ b/skills/run-litd/remote-signer/routing-node.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# litd Routing Node Setup Script for Ubuntu (Source Build Prerequisites)
+# Installs Go, Node.js, and Yarn — run this before routing-node2.sh.
+
+set -e  # Exit on any command failure
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+GO_BIN_DIR="$USER_HOME/go/bin"
+GO_VERSION="1.23.9"
+NODE_VERSION="24.x"  # Stable Node.js version
+LITD_VERSION="v0.16.1-alpha"  # Version of litd to be installed
+
+# Ensure Go directory exists
+if [[ ! -d "$USER_HOME/go/bin" ]]; then
+    mkdir -p "$USER_HOME/go/bin"
+fi
+
+echo "[+] Ensuring $GO_BIN_DIR is owned by $(id -nu ${SUDO_USER:-$USER}):$(id -ng ${SUDO_USER:-$USER})..."
+sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/go"
+
+# Install Go
+echo "[+] Checking if Go $GO_VERSION is installed..."
+if command -v go &> /dev/null && [[ $(go version | awk '{print $3}' | cut -c3-) == "$GO_VERSION" ]]; then
+    echo "[+] Go $GO_VERSION is already installed. Skipping installation."
+else
+    echo "[+] Installing Go $GO_VERSION..."
+    wget -q "https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz" -O go.tar.gz
+    if [[ -f go.tar.gz ]]; then
+        sudo tar -C /usr/local -xzf go.tar.gz
+        rm go.tar.gz
+
+        # Update .profile for the invoking user
+        sudo -u ${SUDO_USER:-$USER} bash -c "
+        if ! grep -q 'export GOPATH=$USER_HOME/go' $USER_HOME/.profile; then
+            echo 'export GOPATH=$USER_HOME/go' >> $USER_HOME/.profile
+        fi
+        if ! grep -q 'export PATH=$USER_HOME/go/bin:/usr/local/go/bin:\$PATH' $USER_HOME/.profile; then
+            echo 'export PATH=$USER_HOME/go/bin:/usr/local/go/bin:\$PATH' >> $USER_HOME/.profile
+        fi
+        "
+
+        # Export variables for the current session
+        export GOPATH="$USER_HOME/go"
+        export PATH="$USER_HOME/go/bin:/usr/local/go/bin:$PATH"
+
+        echo "[+] Go $GO_VERSION installed successfully!"
+    else
+        echo "[-] Failed to download Go tarball. Exiting."
+        exit 1
+    fi
+fi
+
+# Install Node.js
+echo "[+] Checking if Node.js is installed..."
+if command -v node &> /dev/null && [[ $(node -v | grep -oP '\d+' | head -1) -ge 18 ]]; then
+    echo "[+] Node.js is already installed. Version: $(node -v)"
+else
+    echo "[+] Installing Node.js (stable release)..."
+    sudo apt-get install -y curl
+    curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION -o nodesource_setup.sh
+    sudo -E bash nodesource_setup.sh
+    sudo apt-get install -y nodejs
+    echo "[+] Node.js installed successfully. Version: $(node -v)"
+fi
+
+# Install Yarn
+echo "[+] Checking if Yarn is installed..."
+if command -v yarn &> /dev/null; then
+    echo "[+] Yarn is already installed. Version: $(yarn --version)"
+else
+    echo "[+] Installing Yarn..."
+    sudo npm install -g yarn
+    echo "[+] Yarn installed successfully. Version: $(yarn --version)"
+fi
+
+echo "[+] Installation and configuration complete!"
+echo "[+] Please verify that GoLang, NodeJS, and Yarn are properly installed."
+echo "[+] Then, end the current bash session and start a new one before running the next script."

--- a/skills/run-litd/remote-signer/routing-node2.sh
+++ b/skills/run-litd/remote-signer/routing-node2.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+
+# litd Routing Node Setup Script for Ubuntu (Source Build)
+# Configures litd as a watch-only routing node backed by a remote signer.
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_CONF_DIR="$USER_HOME/.lit"
+LIT_CONF_FILE="$LIT_CONF_DIR/lit.conf"
+LND_DIR="$USER_HOME/.lnd"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SIGNER_TLS_CERT="$LND_DIR/signer-tls.cert"
+SIGNER_MACAROON="$LND_DIR/signer.macaroon"
+SIGNER_ACCOUNTS="$LND_DIR/accounts.json"
+GO_VERSION="1.23.9"
+NODE_VERSION="24.x"  # Ensure an even-numbered, stable release
+LITD_VERSION="v0.16.1-alpha"  # Version of litd to be installed
+SERVICE_FILE="/etc/systemd/system/litd.service"
+
+
+# Clone and build litd
+echo "[+] Checking if Lightning Terminal is already installed..."
+if [[ -f "$USER_HOME/go/bin/litd" ]]; then
+    echo "[+] Lightning Terminal (litd) is already installed. Skipping build."
+else
+    echo "[+] litd not found in $USER_HOME/go/bin. Proceeding with installation."
+
+    echo "[+] Ensuring $USER_HOME/go directory exists and is owned by the current user..."
+    if [[ -d "$USER_HOME/go" ]]; then
+        echo "[+] Directory $USER_HOME/go already exists."
+    else
+        echo "[+] Creating $USER_HOME/go directory..."
+        mkdir -p "$USER_HOME/go"
+        echo "[+] Directory $USER_HOME/go created successfully."
+    fi
+    echo "[+] Ensuring proper ownership of $USER_HOME/go..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/go"
+
+    # Ensure required build tools are installed
+    echo "[+] Checking for required build tools..."
+    if ! command -v make &> /dev/null; then
+        echo "[+] 'make' not found. Installing build-essential package..."
+        sudo apt update
+        sudo apt install build-essential -y
+    else
+        echo "[+] 'make' is already installed."
+    fi
+
+    echo "[+] Checking if Lightning Terminal repository already exists..."
+    if [[ -d "$USER_HOME/lightning-terminal" ]]; then
+        echo "[!] Repository already exists. Using existing directory."
+        cd "$USER_HOME/lightning-terminal"
+    else
+        echo "[+] Cloning Lightning Terminal repository into $USER_HOME/lightning-terminal..."
+        if git clone https://github.com/lightninglabs/lightning-terminal.git "$USER_HOME/lightning-terminal"; then
+            echo "[+] Repository cloned successfully."
+            cd "$USER_HOME/lightning-terminal"
+            # Ensure Lightning Terminal directory ownership
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/lightning-terminal"
+        else
+            echo "[-] Failed to clone repository. Check your internet connection and permissions."
+            exit 1
+        fi
+    fi
+
+    echo "[+] Checking out version $LITD_VERSION..."
+    if git checkout tags/$LITD_VERSION; then
+        echo "[+] Checked out version $LITD_VERSION."
+        echo "[+] Building litd... This might take a few minutes."
+        export GOPATH=$USER_HOME/go
+        export PATH=$USER_HOME/go/bin:/usr/local/go/bin:$PATH
+        if make install && make go-install-cli; then
+            echo "[+] litd successfully built and installed!"
+            # Ensure binary ownership
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/go"
+            
+            # Ensure lightning-terminal directory ownership
+            echo "[+] Ensuring proper ownership of $USER_HOME/lightning-terminal..."
+            sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} "$USER_HOME/lightning-terminal"
+        else
+            echo "[-] Failed to build and install litd. Check for errors in the build process."
+            exit 1
+        fi
+    else
+        echo "[-] Failed to checkout version $LITD_VERSION. Ensure the tag exists."
+        exit 1
+    fi
+fi
+
+# Ensure ~/.lnd directory exists
+echo "[+] Ensuring the ~/.lnd directory exists..."
+if [[ ! -d $LND_DIR ]]; then
+    mkdir -p $LND_DIR
+    echo "[+] Created directory at $LND_DIR."
+    # Ensure ~/.lnd directory is owned by the user
+    echo "[+] Ensuring ownership of $LND_DIR..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LND_DIR
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LND_DIR."
+else
+    echo "[!] Directory $LND_DIR already exists."
+fi
+
+# Generate wallet password
+echo "[+] Checking if wallet password file exists and is not empty..."
+if [[ -f $WALLET_PASSWORD_FILE && -s $WALLET_PASSWORD_FILE ]]; then
+    echo "[+] Wallet password file already exists and is not empty. Skipping generation."
+else
+    echo "[+] Generating wallet password..."
+    openssl rand -hex 21 > $WALLET_PASSWORD_FILE
+    if [[ -f $WALLET_PASSWORD_FILE ]]; then
+        echo "[+] Wallet password generated and saved to $WALLET_PASSWORD_FILE."
+        # Ensure wallet password file is owned by the user
+        echo "[+] Ensuring ownership of $WALLET_PASSWORD_FILE..."
+        sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $WALLET_PASSWORD_FILE
+        echo "[+] Ownership set to ${SUDO_USER:-$USER} for $WALLET_PASSWORD_FILE."
+    else
+        echo "[-] Failed to generate wallet password. Exiting."
+        exit 1
+    fi
+fi
+
+# Check for required signer files
+echo "[+] Checking for required signer files..."
+MISSING_FILES=0
+for FILE in "$SIGNER_TLS_CERT" "$SIGNER_MACAROON" "$SIGNER_ACCOUNTS"; do
+    if [[ ! -f "$FILE" ]]; then
+        echo "[-] Missing required signer file: $FILE"
+        MISSING_FILES=1
+    fi
+done
+if [[ $MISSING_FILES -eq 1 ]]; then
+    echo "[-] One or more required signer files are missing."
+    echo "    Copy the following files from your signer node to this server, then re-run this script."
+    echo "    Note: the signer's tls.cert must be renamed to signer-tls.cert to avoid conflict with"
+    echo "    the routing node's own tls.cert."
+    echo ""
+    echo "    scp user@<signer-ip>:~/.lnd/tls.cert        $SIGNER_TLS_CERT"
+    echo "    scp user@<signer-ip>:~/.lnd/signer.macaroon $SIGNER_MACAROON"
+    echo "    scp user@<signer-ip>:~/.lnd/accounts.json   $SIGNER_ACCOUNTS"
+    echo ""
+    echo "    Once copied, re-run this script to continue. All completed steps will be skipped."
+    exit 1
+fi
+echo "[+] All required signer files found."
+
+# Configure litd
+echo "[+] Step 4: Configuring Lightning Terminal (litd)..."
+
+# Check if configuration directory exists
+if [[ ! -d $LIT_CONF_DIR ]]; then
+    mkdir -p $LIT_CONF_DIR
+    echo "[+] Created configuration directory at $LIT_CONF_DIR."
+    # Ensure .lit directory is owned by the user
+    echo "[+] Ensuring ownership of $LIT_CONF_DIR..."
+    sudo chown -R ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_DIR
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LIT_CONF_DIR."
+else
+    echo "[!] $LIT_CONF_DIR already exists."
+fi
+
+# Check if configuration file exists and is not empty
+if [[ -f $LIT_CONF_FILE && -s $LIT_CONF_FILE ]]; then
+    echo "[+] Configuration file already exists and is not empty. Skipping creation."
+else
+    echo "[+] Generating new configuration file..."
+
+    read -p "Is your bitcoind backend running on mainnet or signet? [mainnet/signet]: " NETWORK
+    NETWORK=$(echo "$NETWORK" | tr '[:upper:]' '[:lower:]')
+    if [[ $NETWORK != "mainnet" && $NETWORK != "signet" ]]; then
+        echo "[-] Invalid network selection. Please choose either 'mainnet' or 'signet'."
+        exit 1
+    fi
+
+    read -s -p "Enter the RPC password for your bitcoind backend: " RPC_PASSWORD
+    echo
+    if [[ -z $RPC_PASSWORD ]]; then
+        echo "[-] RPC password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -s -p "Enter a UI password for litd: " UI_PASSWORD
+    echo
+    if [[ -z $UI_PASSWORD ]]; then
+        echo "[-] UI password cannot be empty. Exiting."
+        exit 1
+    fi
+
+    read -p "Enter a Lightning Node alias: " NODE_ALIAS
+
+    read -p "Enter the remote signer's IP address or hostname: " SIGNER_IP
+    if [[ -z $SIGNER_IP ]]; then
+        echo "[-] Signer IP cannot be empty. Exiting."
+        exit 1
+    fi
+
+    # Prepare the base configuration content
+    CONFIG_CONTENT="# Litd Settings
+enablerest=true
+httpslisten=0.0.0.0:8443
+uipassword=$UI_PASSWORD
+network=$NETWORK
+lnd-mode=integrated
+pool-mode=disable
+loop-mode=disable
+autopilot.disable=true
+
+# Bitcoin Configuration
+lnd.bitcoin.active=1
+lnd.bitcoin.node=bitcoind
+lnd.bitcoind.rpchost=127.0.0.1
+lnd.bitcoind.rpcuser=bitcoinrpc
+lnd.bitcoind.rpcpass=$RPC_PASSWORD
+lnd.bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+lnd.bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+
+# LND General Settings
+#lnd.wallet-unlock-password-file=/home/ubuntu/.lnd/wallet_password
+#lnd.wallet-unlock-allow-create=true
+lnd.debuglevel=debug
+lnd.alias=$NODE_ALIAS
+lnd.maxpendingchannels=3
+lnd.accept-keysend=true
+lnd.accept-amp=true
+lnd.rpcmiddleware.enable=true
+lnd.autopilot.active=0
+
+# LND Protocol Settings
+lnd.protocol.simple-taproot-chans=true
+lnd.protocol.simple-taproot-overlay-chans=true
+lnd.protocol.option-scid-alias=true
+lnd.protocol.zero-conf=true
+lnd.protocol.custom-message=17
+
+# Remote Signer Settings
+lnd.remotesigner.enable=true
+lnd.remotesigner.rpchost=$SIGNER_IP:10009
+lnd.remotesigner.tlscertpath=$SIGNER_TLS_CERT
+lnd.remotesigner.macaroonpath=$SIGNER_MACAROON
+
+# Taproot Assets Settings
+#taproot-assets.rpclisten=0.0.0.0:10029
+#taproot-assets.allow-public-uni-proof-courier=true
+#taproot-assets.allow-public-stats=true
+#taproot-assets.universe.public-access=rw
+#taproot-assets.experimental.rfq.skipacceptquotepricecheck=true
+#taproot-assets.experimental.rfq.priceoracleaddress=rfqrpc://127.0.0.1:8095
+#taproot-assets.experimental.rfq.priceoracleaddress=use_mock_price_oracle_service_promise_to_not_use_on_mainnet
+#taproot-assets.experimental.rfq.mockoracleassetsperbtc=100000000"
+
+    # Apply mainnet-specific logic
+    if [[ $NETWORK == "mainnet" ]]; then
+        CONFIG_CONTENT=$(echo "$CONFIG_CONTENT" | sed "/pool-mode=disable/s/^/# /" | sed "/loop-mode=disable/s/^/# /" | sed "/autopilot.disable=true/s/^/# /")
+    fi
+
+    # Write configuration content to file
+    echo "$CONFIG_CONTENT" > $LIT_CONF_FILE
+    echo "[+] Configuration file created at $LIT_CONF_FILE."
+
+    # Ensure configuration file is owned by the user
+    echo "[+] Ensuring ownership of $LIT_CONF_FILE..."
+    sudo chown ${SUDO_USER:-$USER}:${SUDO_USER:-$USER} $LIT_CONF_FILE
+    echo "[+] Ownership set to ${SUDO_USER:-$USER} for $LIT_CONF_FILE."
+fi
+
+echo ""
+echo "[+] Build complete! Binaries are installed to $USER_HOME/go/bin."
+echo "    If litd or lncli are not found, start a new shell session or run:"
+echo "      source ~/.profile"
+echo ""
+echo "Now you have a task! Start litd with $ litd, do so as the user who will be running litd."
+echo "Initialize the watch-only wallet using:"
+echo "  $ lncli --network=[yournetwork] createwatchonly ~/.lnd/accounts.json"
+echo "Use the already generated password which can be found via $ cat ~/.lnd/wallet_password"
+echo "Then, stop litd, and run the next script... almost there!!!"

--- a/skills/run-litd/remote-signer/routing-node3.sh
+++ b/skills/run-litd/remote-signer/routing-node3.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# litd Routing Node Setup Script for Ubuntu (Systemd Service)
+# Enables wallet auto-unlock and starts litd as a systemd service.
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Variables
+USER_HOME=$(eval echo ~${SUDO_USER:-$USER})
+LIT_CONF_DIR="$USER_HOME/.lit"
+LIT_CONF_FILE="$LIT_CONF_DIR/lit.conf"
+LND_DIR="$USER_HOME/.lnd"
+WALLET_PASSWORD_FILE="$LND_DIR/wallet_password"
+SERVICE_FILE="/etc/systemd/system/litd.service"
+
+# Uncomment wallet unlock settings in the configuration file
+echo "[+] Uncommenting wallet unlock settings in the configuration file..."
+sed -i "s|^#lnd.wallet-unlock-password-file=/home/ubuntu/.lnd/wallet_password|lnd.wallet-unlock-password-file=$USER_HOME/.lnd/wallet_password|" $LIT_CONF_FILE
+sed -i "s|^#lnd.wallet-unlock-allow-create=true|lnd.wallet-unlock-allow-create=true|" $LIT_CONF_FILE
+
+echo "[+] Wallet unlock settings have been enabled in $LIT_CONF_FILE."   
+
+# Find the path to the litd binary using the original user’s login shell
+LITD_PATH=$(sudo -i -u "${SUDO_USER:-$USER}" which litd)
+
+# Ensure litd binary is found
+if [[ -z "$LITD_PATH" ]]; then
+    echo "[!] Error: 'litd' binary not found in PATH."
+    exit 1
+fi
+
+# Create systemd service file
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    echo "[+] Creating systemd service file for litd..."
+    cat <<EOF > $SERVICE_FILE
+[Unit]
+Description=Litd Terminal Daemon
+Requires=bitcoind.service
+After=bitcoind.service
+
+[Service]
+ExecStart=$LITD_PATH litd
+
+User=${SUDO_USER:-$USER}
+Group=${SUDO_USER:-$USER}
+
+Type=simple
+Restart=always
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+else
+    echo "[!] Systemd service file already exists. Skipping creation."
+fi
+
+# Enable, reload, and start systemd service
+systemctl enable litd
+systemctl daemon-reload
+if ! systemctl is-active --quiet litd; then
+    systemctl start litd
+    echo "[+] litd service started."
+else
+    echo "[!] litd service is already running."
+fi
+
+cat <<'EOF'
+
+[+] Lightning Terminal Daemon (litd) built, configured, and service enabled successfully!
+
+
+             ________________________________________________
+            /                                                \
+           |    _________________________________________     |
+           |   |                                         |    |
+           |   |       ___(                        )     |    |
+           |   |      (                          _)      |    |
+           |   |     (_                       __))       |    |
+           |   |       ((                _____)          |    |
+           |   |         (_________)----'                |    |
+           |   |              _/  /                      |    |
+           |   |             /  _/                       |    |
+           |   |           _/  /                         |    |
+           |   |          / __/                          |    |
+           |   |        _/ /                             |    |
+           |   |       /__/                              |    |
+           |   |      /'                                 |    |
+           |   |_________________________________________|    |
+           |                                                  |
+            \_________________________________________________/
+                   \___________________________________/
+                ___________________________________________
+             _-'    .-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-.  --- `-_
+          _-'.-.-. .---.-.-.-.-.-.-.-.-.-.-.-.-.-.-.--.  .-.-.`-_
+       _-'.-.-.-. .---.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-`__`. .-.-.-.`-_
+    _-'.-.-.-.-. .-----.-.-.-.-.-.-.-.-.-.-.-.-.-.-.-----. .-.-.-.-.`-_
+ _-'.-.-.-.-.-. .---.-. .-------------------------. .-.---. .---.-.-.-.`-_
+:-------------------------------------------------------------------------:
+`---._.-------------------------------------------------------------._.---'
+
+[+] Your Litd node is now up and running!
+
+[+] Next step: connect to a peer to sync the Lightning graph.
+    Without at least one peer, your node will show "synced_to_graph: false".
+
+    Find a signet peer and connect with:
+      lncli --network=<mainnet|signet> connect <pubkey>@<host>:<port>
+EOF


### PR DESCRIPTION
## Summary

Adds a new \`run-litd\` skill for setting up litd (Lightning Terminal) and LND on bare-metal Ubuntu 24.04. This is a native install skill (binary or source, systemd services, direct config files) that complements the existing \`lnd\` skill for users deploying to dedicated Ubuntu servers rather than Docker environments.

### What it covers

- **Neutrino single node** (default — lightweight SPV, no bitcoind required)
- **Bitcoind + litd node** (full Bitcoin backend for mainnet routing)
- **Remote signer architecture** — signer node (LND, holds keys, off-network) + routing node (litd, watch-only, internet-exposed)
- **Binary and source build paths** for all setups
- **Automated wallet creation** via LND REST API (\`litd_wallet_create.sh\`) — no manual multi-terminal workflow

### Notes

This skill uses a different structure to the existing Docker-based skills — scripts are the actual setup scripts rather than Docker wrappers, and config is generated inline rather than from templates. Happy to discuss whether/how to align the structure if that's preferred.

### Test plan

- [x] Tested on Ubuntu 24.04 LTS (signet, binary install)
- [x] Neutrino single node — full setup in 4 minutes
- [x] Remote signer (signer + routing node, binary and source builds)
- [ ] Mainnet test pending