### PR TITLE
fix: run-litd script fixes for LND v0.20.1 and mainnet Neutrino

### DIFF
--- a/skills/run-litd/SKILL.md
+++ b/skills/run-litd/SKILL.md
@@ -379,6 +379,7 @@ lncli --network=signet --macaroonpath=~/.lnd/signer.macaroon \
 | Pitfall | Fix |
 |---------|-----|
 | `synced_to_graph: false` on routing node | Connect to at least one peer: `lncli connect <pubkey>@<host>:<port>` |
+| Neutrino stuck at `num_peers: 0` on mainnet | No hardcoded mainnet peers — LND uses DNS seeding which can take a few minutes. If still 0, test a candidate peer with `nc -zv <host> 8333` and add working ones to `lnd.conf` as `neutrino.connect=<host>:8333`. |
 | Script exits "Missing required signer file" | Run `scp` to copy all three files from signer — see Step 2 above. Don't forget to rename `tls.cert` → `signer-tls.cert`. |
 | `tls.cert` and `signer-tls.cert` confusion | The routing node generates its own `~/.lit/tls.cert`. The signer's cert must live at `~/.lnd/signer-tls.cert`. `lit.conf` must point `remotesigner.tlscertpath` to the signer cert, not the local one. |
 | Watch-only wallet creation fails | `createwatchonly` must be run while litd is running but *before* auto-unlock lines are uncommented in `lit.conf`. Run `routing-node3.sh` only after the wallet exists. |

--- a/skills/run-litd/neutrino/neutrino_setup_binary.sh
+++ b/skills/run-litd/neutrino/neutrino_setup_binary.sh
@@ -28,12 +28,10 @@ KEY_ID="26984CB69EB8C4A26196F7A4D7D916376026F177"
 KEY_SERVER="hkps://keyserver.ubuntu.com"
 DOWNLOAD_DIR="/tmp/litd_release_verification"
 
-# Default Neutrino peers
-# These must support BIP 157/158 compact block filters.
-MAINNET_PEERS=(
-    "btcd-mainnet.lightning.computer:8333"
-    "node.lightning.directory:8333"
-)
+# Default Neutrino peers (must support BIP 157/158 compact block filters)
+# No hardcoded mainnet peers — LND discovers peers via Bitcoin DNS seeds automatically.
+# Add peers manually when prompted, or leave blank to rely on DNS seeding.
+MAINNET_PEERS=()
 SIGNET_PEERS=(
     "172.233.20.188:38333"
 )
@@ -55,7 +53,10 @@ else
     cd "$DOWNLOAD_DIR" || { echo "[-] Failed to navigate to download directory."; exit 1; }
 
     echo "[+] Importing signing key..."
-    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+    if ! curl -sf "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$KEY_ID" | gpg --import 2>/dev/null; then
+        echo "[!] HTTPS key fetch failed, trying HKP..."
+        gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+    fi
 
     echo "[+] Downloading litd binary, signature, and manifest..."
     wget "$BINARY_URL"   || { echo "[-] Failed to download binary."; exit 1; }
@@ -154,7 +155,7 @@ else
     if [[ "$NETWORK" == "mainnet" ]]; then
         DEFAULT_PEERS=("${MAINNET_PEERS[@]}")
         NETWORK_FLAG="lnd.bitcoin.mainnet=1"
-        FEE_LINE="lnd.neutrino.feeurl=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json"
+        FEE_LINE="lnd.fee.url=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json"
         SIGNET_OPTS="#pool-mode=disable
 #loop-mode=disable
 #autopilot.disable=true"

--- a/skills/run-litd/neutrino/remote-signer-neutrino-binary.sh
+++ b/skills/run-litd/neutrino/remote-signer-neutrino-binary.sh
@@ -32,10 +32,9 @@ KEY_SERVER="hkps://keyserver.ubuntu.com"
 DOWNLOAD_DIR="/tmp/lnd_release_verification"
 
 # Default Neutrino peers (must support BIP 157/158 compact block filters)
-MAINNET_PEERS=(
-    "btcd-mainnet.lightning.computer:8333"
-    "node.lightning.directory:8333"
-)
+# No hardcoded mainnet peers — LND discovers peers via Bitcoin DNS seeds automatically.
+# Add peers manually when prompted, or leave blank to rely on DNS seeding.
+MAINNET_PEERS=()
 SIGNET_PEERS=(
     "172.233.20.188:38333"
 )

--- a/skills/run-litd/neutrino/remote-signer-neutrino-binary.sh
+++ b/skills/run-litd/neutrino/remote-signer-neutrino-binary.sh
@@ -60,7 +60,10 @@ else
     cd "$DOWNLOAD_DIR" || { echo "[-] Failed to navigate to download directory."; exit 1; }
 
     echo "[+] Importing LND signing key..."
-    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+    if ! curl -sf "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$KEY_ID" | gpg --import 2>/dev/null; then
+        echo "[!] HTTPS key fetch failed, trying HKP..."
+        gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+    fi
 
     echo "[+] Downloading LND binary, manifest, and signature..."
     wget "$BINARY_URL"    || { echo "[-] Failed to download binary."; exit 1; }
@@ -158,7 +161,7 @@ else
     if [[ "$NETWORK" == "mainnet" ]]; then
         DEFAULT_PEERS=("${MAINNET_PEERS[@]}")
         NETWORK_FLAG="bitcoin.mainnet=1"
-        FEE_LINE="neutrino.feeurl=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json"
+        FEE_LINE=$'\n[Fee]\nfee.url=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json'
     else
         DEFAULT_PEERS=("${SIGNET_PEERS[@]}")
         NETWORK_FLAG="bitcoin.signet=1"
@@ -265,7 +268,12 @@ MACAROON_PATH="$LND_DIR/data/chain/bitcoin/$NETWORK/admin.macaroon"
 SEED_FILE="$LND_DIR/seed_phrase.txt"
 XPUB_FILE="$LND_DIR/accounts.json"
 SIGNER_MACAROON="$LND_DIR/signer.macaroon"
-TIMEOUT=180
+# mainnet Neutrino takes significantly longer to start than signet
+if [[ "$NETWORK" == "mainnet" ]]; then
+    TIMEOUT=600
+else
+    TIMEOUT=180
+fi
 
 if [[ -f "$MACAROON_PATH" ]]; then
     echo "[!] Wallet already initialized. Skipping wallet setup."
@@ -275,6 +283,7 @@ else
     ELAPSED=0
     while [[ ! -f "$LND_DIR/tls.cert" ]]; do
         sleep 2; ELAPSED=$((ELAPSED + 2))
+        if ! systemctl is-active --quiet lnd; then echo "[-] lnd exited unexpectedly — check 'journalctl -u lnd' for errors."; exit 1; fi
         if [[ $ELAPSED -ge $TIMEOUT ]]; then echo "[-] Timed out waiting for TLS cert."; exit 1; fi
     done
     echo "[+] TLS certificate ready."

--- a/skills/run-litd/neutrino/remote-signer-neutrino-binary.sh
+++ b/skills/run-litd/neutrino/remote-signer-neutrino-binary.sh
@@ -160,7 +160,7 @@ else
     if [[ "$NETWORK" == "mainnet" ]]; then
         DEFAULT_PEERS=("${MAINNET_PEERS[@]}")
         NETWORK_FLAG="bitcoin.mainnet=1"
-        FEE_LINE=$'\n[Fee]\nfee.url=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json'
+        FEE_LINE=$'\n[fee]\nfee.url=https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json'
     else
         DEFAULT_PEERS=("${SIGNET_PEERS[@]}")
         NETWORK_FLAG="bitcoin.signet=1"

--- a/skills/run-litd/remote-signer/remote-signer-binary.sh
+++ b/skills/run-litd/remote-signer/remote-signer-binary.sh
@@ -42,7 +42,10 @@ else
     cd "$DOWNLOAD_DIR" || { echo "[-] Failed to navigate to download directory."; exit 1; }
 
     echo "[+] Importing LND signing key..."
-    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+    if ! curl -sf "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$KEY_ID" | gpg --import 2>/dev/null; then
+        echo "[!] HTTPS key fetch failed, trying HKP..."
+        gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+    fi
 
     echo "[+] Downloading LND binary..."
     wget "$BINARY_URL" || { echo "[-] Failed to download binary."; exit 1; }

--- a/skills/run-litd/remote-signer/routing-node-binary.sh
+++ b/skills/run-litd/remote-signer/routing-node-binary.sh
@@ -39,7 +39,10 @@ else
 
     # Import Signing key
     echo "Importing Signing key..."
-    gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "Failed to import PGP key."; exit 1; }
+    if ! curl -sf "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$KEY_ID" | gpg --import 2>/dev/null; then
+        echo "[!] HTTPS key fetch failed, trying HKP..."
+        gpg --keyserver "$KEY_SERVER" --recv-keys "$KEY_ID" || { echo "[-] Failed to import PGP key."; exit 1; }
+    fi
 
     # Download litd binary
     echo "Downloading binary..."


### PR DESCRIPTION
## Summary

Fixes discovered during mainnet testing of the `run-litd` skill on Ubuntu 24.04.

- **GPG keyserver fallback** — HKP (port 11371) is blocked on some hosts. All four binary install scripts now try the keyserver HTTPS REST API first and fall back to HKP if that fails.
- **`fee.url` rename** — `neutrino.feeurl` was removed in LND v0.20.1. Updated `remote-signer-neutrino-binary.sh` to use `fee.url` under a `[fee]` section in `lnd.conf`, and `neutrino_setup_binary.sh` to use `lnd.fee.url` in `lit.conf`.
- **`neutrino.connect=` prefix required** — LND v0.20.1 requires the fully-qualified key name even inside `[Neutrino]` section headers.
- **Mainnet timeout** — Raised from 180s to 600s for mainnet Neutrino (sync takes significantly longer than signet). Added a lnd liveness check so a bad config causes an immediate fail with a useful error rather than silently waiting out the full timeout.
- **Dead mainnet peers removed** — `btcd-mainnet.lightning.computer` (connection refused) and `node.lightning.directory` (SERVFAIL) are both unreachable. Removed hardcoded mainnet peers and rely on LND's built-in Bitcoin DNS seeding instead. Added a Common Pitfalls entry explaining the behaviour.

## Test results

| Test | Result |
|------|--------|
| `remote-signer-neutrino-binary.sh` mainnet (Run 1) | GPG + config fixes confirmed |
| `remote-signer-neutrino-binary.sh` mainnet (Run 2) | Single script run, ~3 min, no issues |
| `neutrino_setup_binary.sh` mainnet | `lnd.fee.url` accepted, DNS seeding found peers, `synced_to_chain: true` |

`routing-node-binary.sh` and `remote-signer-binary.sh` GPG fix is structurally identical to the tested scripts.