### PR TITLE
feat(mcp): add read-only propose_fees tool

### DIFF
--- a/lightning-mcp-server/internal/services/manager.go
+++ b/lightning-mcp-server/internal/services/manager.go
@@ -35,6 +35,7 @@ type Manager struct {
 	onchainService    *tools.OnChainService
 	peerService       *tools.PeerService
 	nodeService       *tools.NodeService
+	feeService        *tools.FeeService
 }
 
 // NewManager creates a new service manager for read-only operations.
@@ -60,6 +61,7 @@ func (m *Manager) InitializeServices() {
 	m.onchainService = tools.NewOnChainService(nil)
 	m.peerService = tools.NewPeerService(nil)
 	m.nodeService = tools.NewNodeService(nil)
+	m.feeService = tools.NewFeeService(nil)
 
 	m.logger.Info("Read-only services initialized successfully")
 }
@@ -128,6 +130,10 @@ func (m *Manager) RegisterTools(mcpServer interfaces.MCPServer) error {
 	register(m.nodeService.GetInfoTool(),
 		m.nodeService.HandleGetInfo)
 
+	// Fee proposal tool - read-only operations.
+	register(m.feeService.ProposeFeesTool(),
+		m.feeService.HandleProposeFees)
+
 	m.logger.Info("Read-only MCP tools registered",
 		zap.Int("total_tools", registrations))
 	return nil
@@ -149,6 +155,7 @@ func (m *Manager) onLNCConnectionEstablished(conn *grpc.ClientConn) {
 	m.onchainService.LightningClient = m.lightningClient
 	m.peerService.LightningClient = m.lightningClient
 	m.nodeService.LightningClient = m.lightningClient
+	m.feeService.LightningClient = m.lightningClient
 
 	logger.Info("All read-only services updated with new connection")
 }

--- a/lightning-mcp-server/tools/fees.go
+++ b/lightning-mcp-server/tools/fees.go
@@ -101,7 +101,13 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 
 	// Bug fix: paginate ForwardingHistory so nodes with more than 50 000
 	// events in the window are not silently truncated.
-	var allEvents []*lnrpc.ForwardingEvent
+	type chanStats struct {
+		forwardsOut  int64
+		amtOutMsat   int64
+		feesEarnedMs int64
+	}
+	stats := make(map[uint64]*chanStats)
+	totalForwards := 0
 	var offset uint32
 	for {
 		batch, err := s.LightningClient.ForwardingHistory(
@@ -115,7 +121,18 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 			return newToolResultError(
 				"Failed to fetch forwarding history: " + err.Error()), nil
 		}
-		allEvents = append(allEvents, batch.ForwardingEvents...)
+
+		totalForwards += len(batch.ForwardingEvents)
+		for _, ev := range batch.ForwardingEvents {
+			if _, ok := stats[ev.ChanIdOut]; !ok {
+				stats[ev.ChanIdOut] = &chanStats{}
+			}
+			s2 := stats[ev.ChanIdOut]
+			s2.forwardsOut++
+			s2.amtOutMsat += int64(ev.AmtOutMsat)
+			s2.feesEarnedMs += int64(ev.FeeMsat)
+		}
+
 		if uint32(len(batch.ForwardingEvents)) < feePageSize {
 			break
 		}
@@ -128,22 +145,6 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 	if err != nil {
 		return newToolResultError(
 			"Failed to list channels: " + err.Error()), nil
-	}
-
-	type chanStats struct {
-		forwardsOut  int64
-		amtOutMsat   int64
-		feesEarnedMs int64
-	}
-	stats := make(map[uint64]*chanStats)
-	for _, ev := range allEvents {
-		if _, ok := stats[ev.ChanIdOut]; !ok {
-			stats[ev.ChanIdOut] = &chanStats{}
-		}
-		s2 := stats[ev.ChanIdOut]
-		s2.forwardsOut++
-		s2.amtOutMsat += int64(ev.AmtOutMsat)
-		s2.feesEarnedMs += int64(ev.FeeMsat)
 	}
 
 	proposals := make([]map[string]any, 0, len(channels.Channels))
@@ -162,7 +163,7 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 		proposedPPM := proposeFee(localRatio, forwards, minFeePPM, maxFeePPM)
 
 		entry := map[string]any{
-			"chan_id":           strconv.FormatUint(ch.ChanId, 10),
+			"chan_id":          strconv.FormatUint(ch.ChanId, 10),
 			"remote_pubkey":    ch.RemotePubkey,
 			"channel_point":    ch.ChannelPoint,
 			"capacity_sat":     ch.Capacity,
@@ -181,8 +182,8 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 	}
 
 	return newToolResultJSON(map[string]any{
-		"lookback_days":  int(days),
-		"total_forwards": len(allEvents),
+		"lookback_days":  days,
+		"total_forwards": totalForwards,
 		"proposals":      proposals,
 		"note":           "Proposals are suggestions only. Apply with UpdateChannelPolicy after review.",
 	}), nil

--- a/lightning-mcp-server/tools/fees.go
+++ b/lightning-mcp-server/tools/fees.go
@@ -17,6 +17,9 @@ type FeeService struct {
 	LightningClient lnrpc.LightningClient
 }
 
+// feePageSize is the maximum number of forwarding events fetched per page.
+const feePageSize uint32 = 50000
+
 // NewFeeService creates a new FeeService.
 func NewFeeService(client lnrpc.LightningClient) *FeeService {
 	return &FeeService{LightningClient: client}
@@ -81,17 +84,42 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 		maxFeePPM = 5000
 	}
 
-	startTime := uint64(time.Now().Add(-time.Duration(days) * 24 * time.Hour).Unix())
-
-	history, err := s.LightningClient.ForwardingHistory(
-		ctx, &lnrpc.ForwardingHistoryRequest{
-			StartTime:    startTime,
-			NumMaxEvents: 50000,
-		},
-	)
-	if err != nil {
+	// Bug fix: reject inverted bounds before making any API calls.
+	if minFeePPM > maxFeePPM {
 		return newToolResultError(
-			"Failed to fetch forwarding history: " + err.Error()), nil
+			"min_fee_ppm must not exceed max_fee_ppm"), nil
+	}
+
+	// Bug fix: convert fractional days to nanoseconds correctly so that
+	// values like 1.5 produce the right duration rather than truncating to
+	// the nearest integer day.
+	startTime := uint64(
+		time.Now().Add(
+			-time.Duration(days * 24 * float64(time.Hour)),
+		).Unix(),
+	)
+
+	// Bug fix: paginate ForwardingHistory so nodes with more than 50 000
+	// events in the window are not silently truncated.
+	var allEvents []*lnrpc.ForwardingEvent
+	var offset uint32
+	for {
+		batch, err := s.LightningClient.ForwardingHistory(
+			ctx, &lnrpc.ForwardingHistoryRequest{
+				StartTime:    startTime,
+				NumMaxEvents: feePageSize,
+				IndexOffset:  offset,
+			},
+		)
+		if err != nil {
+			return newToolResultError(
+				"Failed to fetch forwarding history: " + err.Error()), nil
+		}
+		allEvents = append(allEvents, batch.ForwardingEvents...)
+		if uint32(len(batch.ForwardingEvents)) < feePageSize {
+			break
+		}
+		offset = batch.LastOffsetIndex + 1
 	}
 
 	channels, err := s.LightningClient.ListChannels(
@@ -108,7 +136,7 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 		feesEarnedMs int64
 	}
 	stats := make(map[uint64]*chanStats)
-	for _, ev := range history.ForwardingEvents {
+	for _, ev := range allEvents {
 		if _, ok := stats[ev.ChanIdOut]; !ok {
 			stats[ev.ChanIdOut] = &chanStats{}
 		}
@@ -134,16 +162,16 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 		proposedPPM := proposeFee(localRatio, forwards, minFeePPM, maxFeePPM)
 
 		entry := map[string]any{
-			"chan_id":          strconv.FormatUint(ch.ChanId, 10),
-			"remote_pubkey":   ch.RemotePubkey,
-			"channel_point":   ch.ChannelPoint,
-			"capacity_sat":    ch.Capacity,
-			"local_balance":   ch.LocalBalance,
-			"remote_balance":  ch.RemoteBalance,
-			"local_ratio":     round2(localRatio),
-			"forwards_out":    forwards,
+			"chan_id":           strconv.FormatUint(ch.ChanId, 10),
+			"remote_pubkey":    ch.RemotePubkey,
+			"channel_point":    ch.ChannelPoint,
+			"capacity_sat":     ch.Capacity,
+			"local_balance":    ch.LocalBalance,
+			"remote_balance":   ch.RemoteBalance,
+			"local_ratio":      round2(localRatio),
+			"forwards_out":     forwards,
 			"proposed_fee_ppm": proposedPPM,
-			"reason":          feeReason(localRatio, forwards),
+			"reason":           feeReason(localRatio, forwards),
 		}
 		if st != nil {
 			entry["amt_routed_msat"] = st.amtOutMsat
@@ -153,10 +181,10 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 	}
 
 	return newToolResultJSON(map[string]any{
-		"lookback_days":   int(days),
-		"total_forwards":  len(history.ForwardingEvents),
-		"proposals":       proposals,
-		"note":            "Proposals are suggestions only. Apply with UpdateChannelPolicy after review.",
+		"lookback_days":  int(days),
+		"total_forwards": len(allEvents),
+		"proposals":      proposals,
+		"note":           "Proposals are suggestions only. Apply with UpdateChannelPolicy after review.",
 	}), nil
 }
 
@@ -172,8 +200,9 @@ func proposeFee(localRatio float64, forwards int64, minPPM, maxPPM float64) int6
 	var ppm float64
 	switch {
 	case localRatio < 0.2:
-		// Depleted — push fee toward max to slow down outflow.
-		ppm = maxPPM * 0.80
+		// Bug fix: use range-relative formula (same pattern as all other
+		// branches) so the result respects minPPM and scales with the range.
+		ppm = minPPM + (maxPPM-minPPM)*0.90
 	case localRatio > 0.8:
 		// Over-full — lower fee to encourage outflow and rebalancing.
 		ppm = minPPM + (maxPPM-minPPM)*0.10

--- a/lightning-mcp-server/tools/fees.go
+++ b/lightning-mcp-server/tools/fees.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// FeeService proposes routing fee adjustments using only read-only RPCs.
+type FeeService struct {
+	LightningClient lnrpc.LightningClient
+}
+
+// NewFeeService creates a new FeeService.
+func NewFeeService(client lnrpc.LightningClient) *FeeService {
+	return &FeeService{LightningClient: client}
+}
+
+// ProposeFeesTool returns the MCP tool definition for propose_fees.
+func (s *FeeService) ProposeFeesTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "lnc_propose_fees",
+		Description: "Analyse routing history and channel balances to propose " +
+			"fee-rate adjustments per channel. Read-only: uses " +
+			"ForwardingHistory and ListChannels only.",
+		InputSchema: ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"days": map[string]any{
+					"type":        "number",
+					"description": "Lookback window in days for forwarding history (default 7, max 90)",
+					"minimum":     1,
+					"maximum":     90,
+				},
+				"min_fee_ppm": map[string]any{
+					"type":        "number",
+					"description": "Minimum proposed fee in parts-per-million (default 1)",
+					"minimum":     1,
+				},
+				"max_fee_ppm": map[string]any{
+					"type":        "number",
+					"description": "Maximum proposed fee in parts-per-million (default 5000)",
+					"minimum":     1,
+				},
+			},
+		},
+	}
+}
+
+// HandleProposeFees handles the propose_fees request.
+func (s *FeeService) HandleProposeFees(ctx context.Context,
+	request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+
+	if s.LightningClient == nil {
+		return newToolResultError(
+			"Not connected to Lightning node. Use lnc_connect first."), nil
+	}
+
+	args := requestArguments(request)
+
+	days, _ := args["days"].(float64)
+	if days <= 0 {
+		days = 7
+	}
+	if days > 90 {
+		days = 90
+	}
+
+	minFeePPM, _ := args["min_fee_ppm"].(float64)
+	if minFeePPM <= 0 {
+		minFeePPM = 1
+	}
+	maxFeePPM, _ := args["max_fee_ppm"].(float64)
+	if maxFeePPM <= 0 {
+		maxFeePPM = 5000
+	}
+
+	startTime := uint64(time.Now().Add(-time.Duration(days) * 24 * time.Hour).Unix())
+
+	history, err := s.LightningClient.ForwardingHistory(
+		ctx, &lnrpc.ForwardingHistoryRequest{
+			StartTime:    startTime,
+			NumMaxEvents: 50000,
+		},
+	)
+	if err != nil {
+		return newToolResultError(
+			"Failed to fetch forwarding history: " + err.Error()), nil
+	}
+
+	channels, err := s.LightningClient.ListChannels(
+		ctx, &lnrpc.ListChannelsRequest{},
+	)
+	if err != nil {
+		return newToolResultError(
+			"Failed to list channels: " + err.Error()), nil
+	}
+
+	type chanStats struct {
+		forwardsOut  int64
+		amtOutMsat   int64
+		feesEarnedMs int64
+	}
+	stats := make(map[uint64]*chanStats)
+	for _, ev := range history.ForwardingEvents {
+		if _, ok := stats[ev.ChanIdOut]; !ok {
+			stats[ev.ChanIdOut] = &chanStats{}
+		}
+		s2 := stats[ev.ChanIdOut]
+		s2.forwardsOut++
+		s2.amtOutMsat += int64(ev.AmtOutMsat)
+		s2.feesEarnedMs += int64(ev.FeeMsat)
+	}
+
+	proposals := make([]map[string]any, 0, len(channels.Channels))
+	for _, ch := range channels.Channels {
+		localRatio := float64(0)
+		if ch.Capacity > 0 {
+			localRatio = float64(ch.LocalBalance) / float64(ch.Capacity)
+		}
+
+		st := stats[ch.ChanId]
+		forwards := int64(0)
+		if st != nil {
+			forwards = st.forwardsOut
+		}
+
+		proposedPPM := proposeFee(localRatio, forwards, minFeePPM, maxFeePPM)
+
+		entry := map[string]any{
+			"chan_id":          strconv.FormatUint(ch.ChanId, 10),
+			"remote_pubkey":   ch.RemotePubkey,
+			"channel_point":   ch.ChannelPoint,
+			"capacity_sat":    ch.Capacity,
+			"local_balance":   ch.LocalBalance,
+			"remote_balance":  ch.RemoteBalance,
+			"local_ratio":     round2(localRatio),
+			"forwards_out":    forwards,
+			"proposed_fee_ppm": proposedPPM,
+			"reason":          feeReason(localRatio, forwards),
+		}
+		if st != nil {
+			entry["amt_routed_msat"] = st.amtOutMsat
+			entry["fees_earned_msat"] = st.feesEarnedMs
+		}
+		proposals = append(proposals, entry)
+	}
+
+	return newToolResultJSON(map[string]any{
+		"lookback_days":   int(days),
+		"total_forwards":  len(history.ForwardingEvents),
+		"proposals":       proposals,
+		"note":            "Proposals are suggestions only. Apply with UpdateChannelPolicy after review.",
+	}), nil
+}
+
+// proposeFee returns a fee in PPM based on local liquidity ratio and recent
+// forward count.
+//
+// Strategy:
+//   - Depleted channel (localRatio < 0.2): raise fees to slow outflow.
+//   - Saturated channel (localRatio > 0.8): lower fees to encourage outflow.
+//   - Idle channel (0 forwards in window): lower fees to attract routing.
+//   - Active balanced channel: scale proportionally between min and max.
+func proposeFee(localRatio float64, forwards int64, minPPM, maxPPM float64) int64 {
+	var ppm float64
+	switch {
+	case localRatio < 0.2:
+		// Depleted — push fee toward max to slow down outflow.
+		ppm = maxPPM * 0.80
+	case localRatio > 0.8:
+		// Over-full — lower fee to encourage outflow and rebalancing.
+		ppm = minPPM + (maxPPM-minPPM)*0.10
+	case forwards == 0:
+		// Idle channel — offer a discount to attract first routes.
+		ppm = minPPM + (maxPPM-minPPM)*0.15
+	default:
+		// Balanced and routing — linear scale: higher local ratio → lower fee.
+		ppm = minPPM + (maxPPM-minPPM)*(1-localRatio)
+	}
+
+	if ppm < minPPM {
+		ppm = minPPM
+	}
+	if ppm > maxPPM {
+		ppm = maxPPM
+	}
+	return int64(ppm)
+}
+
+func feeReason(localRatio float64, forwards int64) string {
+	switch {
+	case localRatio < 0.2:
+		return "depleted: raised fee to slow outflow"
+	case localRatio > 0.8:
+		return "saturated: lowered fee to encourage outflow"
+	case forwards == 0:
+		return "idle: discounted fee to attract routing"
+	default:
+		return "balanced and active: fee scaled by local liquidity ratio"
+	}
+}
+
+func round2(f float64) float64 {
+	return float64(int(f*100)) / 100
+}

--- a/lightning-mcp-server/tools/fees.go
+++ b/lightning-mcp-server/tools/fees.go
@@ -119,7 +119,7 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 		if uint32(len(batch.ForwardingEvents)) < feePageSize {
 			break
 		}
-		offset = batch.LastOffsetIndex + 1
+		offset = batch.LastOffsetIndex
 	}
 
 	channels, err := s.LightningClient.ListChannels(

--- a/lightning-mcp-server/tools/fees_test.go
+++ b/lightning-mcp-server/tools/fees_test.go
@@ -191,10 +191,11 @@ func TestHandleProposeFees_FractionalDays(t *testing.T) {
 
 	before := time.Now()
 	svc := NewFeeService(mock)
-	_, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(map[string]any{
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(map[string]any{
 		"days": 0.5,
 	}))
 	require.NoError(t, err)
+	require.False(t, result.IsError)
 
 	// 0.5 days = 12 hours ago.  Allow ±5 s for test execution.
 	expected := uint64(before.Add(-12 * time.Hour).Unix())
@@ -204,6 +205,11 @@ func TestHandleProposeFees_FractionalDays(t *testing.T) {
 	}
 	assert.LessOrEqual(t, delta, int64(5),
 		"startTime for 0.5 days must be ~12 hours ago, not zero")
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+	assert.Equal(t, 0.5, resp["lookback_days"])
 }
 
 // TestHandleProposeFees_Pagination covers bug-3: history spanning more than

--- a/lightning-mcp-server/tools/fees_test.go
+++ b/lightning-mcp-server/tools/fees_test.go
@@ -215,7 +215,8 @@ func TestHandleProposeFees_Pagination(t *testing.T) {
 	mock := &mockFeeClient{
 		forwardingHistory: func(_ context.Context, in *lnrpc.ForwardingHistoryRequest, _ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
 			callCount++
-			if in.IndexOffset == 0 {
+			if callCount == 1 {
+				require.Equal(t, uint32(0), in.IndexOffset)
 				// First page: return a full page of events.
 				events := make([]*lnrpc.ForwardingEvent, firstPageSize)
 				for i := range events {
@@ -223,9 +224,11 @@ func TestHandleProposeFees_Pagination(t *testing.T) {
 				}
 				return &lnrpc.ForwardingHistoryResponse{
 					ForwardingEvents: events,
-					LastOffsetIndex:  uint32(firstPageSize - 1),
+					LastOffsetIndex:  uint32(firstPageSize),
 				}, nil
 			}
+
+			require.Equal(t, uint32(firstPageSize), in.IndexOffset)
 			// Second page: return one more event to complete pagination.
 			return &lnrpc.ForwardingHistoryResponse{
 				ForwardingEvents: []*lnrpc.ForwardingEvent{

--- a/lightning-mcp-server/tools/fees_test.go
+++ b/lightning-mcp-server/tools/fees_test.go
@@ -1,0 +1,255 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// mockFeeClient satisfies lnrpc.LightningClient for the two methods
+// HandleProposeFees calls; all other methods panic if called.
+type mockFeeClient struct {
+	lnrpc.LightningClient
+	forwardingHistory func(context.Context, *lnrpc.ForwardingHistoryRequest, ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error)
+	listChannels      func(context.Context, *lnrpc.ListChannelsRequest, ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error)
+}
+
+func (m *mockFeeClient) ForwardingHistory(ctx context.Context, in *lnrpc.ForwardingHistoryRequest, opts ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+	return m.forwardingHistory(ctx, in, opts...)
+}
+
+func (m *mockFeeClient) ListChannels(ctx context.Context, in *lnrpc.ListChannelsRequest, opts ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+	return m.listChannels(ctx, in, opts...)
+}
+
+// makeFeeRequest builds a CallToolRequest with the given JSON arguments.
+func makeFeeRequest(args map[string]any) *mcp.CallToolRequest {
+	b, _ := json.Marshal(args)
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Arguments: json.RawMessage(b),
+		},
+	}
+}
+
+// emptyChannelsMock returns a listChannels stub that always returns zero
+// channels — useful when the test only cares about history behaviour.
+func emptyChannelsMock() func(context.Context, *lnrpc.ListChannelsRequest, ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+	return func(_ context.Context, _ *lnrpc.ListChannelsRequest, _ ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+		return &lnrpc.ListChannelsResponse{}, nil
+	}
+}
+
+// --- proposeFee unit tests (bug-4 regression + full branch coverage) ---
+
+func TestProposeFee_DepletedUsesRangeRelativeFormula(t *testing.T) {
+	// Bug 4: old code used maxPPM*0.80 (absolute), new code must use the
+	// range-relative pattern minPPM + (maxPPM-minPPM)*0.90.
+	min, max := 10.0, 1000.0
+	got := proposeFee(0.1, 5, min, max) // localRatio < 0.2 → depleted
+	want := int64(min + (max-min)*0.90) // 10 + 990*0.90 = 901
+	assert.Equal(t, want, got,
+		"depleted branch must use range-relative formula")
+
+	// Demonstrate that the old formula gives a different (wrong) answer when
+	// minPPM != 0.
+	oldFormula := int64(max * 0.80) // 800
+	assert.NotEqual(t, oldFormula, got,
+		"result must differ from the old absolute-percentage formula")
+}
+
+func TestProposeFee_AllBranches(t *testing.T) {
+	min, max := 10.0, 1000.0
+	range_ := max - min // 990
+
+	tests := []struct {
+		name       string
+		localRatio float64
+		forwards   int64
+		want       int64
+	}{
+		{
+			name:       "depleted",
+			localRatio: 0.1,
+			forwards:   3,
+			want:       int64(min + range_*0.90), // 901
+		},
+		{
+			name:       "saturated",
+			localRatio: 0.9,
+			forwards:   3,
+			want:       int64(min + range_*0.10), // 109
+		},
+		{
+			name:       "idle_balanced",
+			localRatio: 0.5,
+			forwards:   0,
+			want:       int64(min + range_*0.15), // 158
+		},
+		{
+			name:       "balanced_active_mid",
+			localRatio: 0.5,
+			forwards:   10,
+			want:       int64(min + range_*(1-0.5)), // 505
+		},
+		{
+			name:       "balanced_active_low_local",
+			localRatio: 0.3,
+			forwards:   10,
+			want:       int64(min + range_*(1-0.3)), // 703
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := proposeFee(tt.localRatio, tt.forwards, min, max)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestProposeFee_Clamping(t *testing.T) {
+	// When min == max every branch should return min (no division by zero).
+	got := proposeFee(0.1, 0, 100, 100)
+	assert.Equal(t, int64(100), got)
+
+	// Result is always within [min, max].
+	got = proposeFee(0.0, 0, 1, 5000)
+	assert.GreaterOrEqual(t, got, int64(1))
+	assert.LessOrEqual(t, got, int64(5000))
+}
+
+// --- FeeService tool-creation tests ---
+
+func TestFeeService_ProposeFeesTool(t *testing.T) {
+	svc := NewFeeService(nil)
+	tool := svc.ProposeFeesTool()
+
+	assert.Equal(t, "lnc_propose_fees", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+
+	schema := requireToolSchema(t, tool.InputSchema)
+	assert.Equal(t, "object", schema.Type)
+	assert.Contains(t, schema.Properties, "days")
+	assert.Contains(t, schema.Properties, "min_fee_ppm")
+	assert.Contains(t, schema.Properties, "max_fee_ppm")
+}
+
+// --- HandleProposeFees handler tests ---
+
+// TestHandleProposeFees_NoClient verifies the "not connected" guard.
+func TestHandleProposeFees_NoClient(t *testing.T) {
+	svc := NewFeeService(nil)
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(nil))
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+// TestHandleProposeFees_InvertedMinMax covers bug-2: inverted bounds must
+// be rejected before any API call is made.
+func TestHandleProposeFees_InvertedMinMax(t *testing.T) {
+	called := false
+	mock := &mockFeeClient{
+		forwardingHistory: func(_ context.Context, _ *lnrpc.ForwardingHistoryRequest, _ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+			called = true
+			return &lnrpc.ForwardingHistoryResponse{}, nil
+		},
+		listChannels: emptyChannelsMock(),
+	}
+
+	svc := NewFeeService(mock)
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(map[string]any{
+		"min_fee_ppm": 5000,
+		"max_fee_ppm": 1,
+	}))
+	require.NoError(t, err)
+	assert.True(t, result.IsError, "inverted bounds must produce an error result")
+	assert.False(t, called, "no API call must be made when bounds are inverted")
+}
+
+// TestHandleProposeFees_FractionalDays covers bug-1: a fractional day value
+// must produce a startTime that is proportionally in the past, not zero.
+func TestHandleProposeFees_FractionalDays(t *testing.T) {
+	var capturedStart uint64
+	mock := &mockFeeClient{
+		forwardingHistory: func(_ context.Context, in *lnrpc.ForwardingHistoryRequest, _ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+			capturedStart = in.StartTime
+			return &lnrpc.ForwardingHistoryResponse{}, nil
+		},
+		listChannels: emptyChannelsMock(),
+	}
+
+	before := time.Now()
+	svc := NewFeeService(mock)
+	_, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(map[string]any{
+		"days": 0.5,
+	}))
+	require.NoError(t, err)
+
+	// 0.5 days = 12 hours ago.  Allow ±5 s for test execution.
+	expected := uint64(before.Add(-12 * time.Hour).Unix())
+	delta := int64(capturedStart) - int64(expected)
+	if delta < 0 {
+		delta = -delta
+	}
+	assert.LessOrEqual(t, delta, int64(5),
+		"startTime for 0.5 days must be ~12 hours ago, not zero")
+}
+
+// TestHandleProposeFees_Pagination covers bug-3: history spanning more than
+// 50 000 events must be fully fetched via multiple pages.
+func TestHandleProposeFees_Pagination(t *testing.T) {
+	const firstPageSize = int(feePageSize) // 50 000 events on first page
+	callCount := 0
+
+	mock := &mockFeeClient{
+		forwardingHistory: func(_ context.Context, in *lnrpc.ForwardingHistoryRequest, _ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+			callCount++
+			if in.IndexOffset == 0 {
+				// First page: return a full page of events.
+				events := make([]*lnrpc.ForwardingEvent, firstPageSize)
+				for i := range events {
+					events[i] = &lnrpc.ForwardingEvent{ChanIdOut: 1}
+				}
+				return &lnrpc.ForwardingHistoryResponse{
+					ForwardingEvents: events,
+					LastOffsetIndex:  uint32(firstPageSize - 1),
+				}, nil
+			}
+			// Second page: return one more event to complete pagination.
+			return &lnrpc.ForwardingHistoryResponse{
+				ForwardingEvents: []*lnrpc.ForwardingEvent{
+					{ChanIdOut: 1},
+				},
+				LastOffsetIndex: uint32(firstPageSize),
+			}, nil
+		},
+		listChannels: emptyChannelsMock(),
+	}
+
+	svc := NewFeeService(mock)
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(nil))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	// Decode response and verify total_forwards includes both pages.
+	text := result.Content[0].(*mcp.TextContent).Text
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+	totalForwards, ok := resp["total_forwards"].(float64)
+	require.True(t, ok)
+	assert.Equal(t, float64(firstPageSize+1), totalForwards,
+		"all events across pages must be counted")
+	assert.Equal(t, 2, callCount, "must make exactly two ForwardingHistory calls")
+}


### PR DESCRIPTION
## Summary

- Adds `lnc_propose_fees` MCP tool in `lightning-mcp-server/tools/fees.go`
- Registers it via minimal additive changes to `lightning-mcp-server/internal/services/manager.go`
- Uses only read-only RPCs: `ForwardingHistory` and `ListChannels`
- No write RPCs introduced (grep-verified)

## What it does

The tool analyses routing activity and channel liquidity ratios over a configurable lookback window (default 7 days, max 90) and proposes fee-rate adjustments in PPM per channel:

| Condition | Strategy |
|---|---|
| `local_ratio < 0.2` (depleted) | Raise fees to slow outflow |
| `local_ratio > 0.8` (saturated) | Lower fees to encourage outflow |
| `forwards == 0` (idle) | Discount to attract routing |
| Balanced and active | Linear scale by local liquidity ratio |

Proposals are advisory only — the tool explicitly notes they must be applied with `UpdateChannelPolicy` after review.

## Test plan

- [x] `cd lightning-mcp-server && go build ./...` passes (Go 1.24+)
- [x] No write RPCs: `grep LightningClient\. tools/fees.go` shows only `ForwardingHistory` and `ListChannels`
- [ ] Manual: connect to a testnet lnd node and call `lnc_propose_fees`

Closes #3