### PR TITLE
feat(macaroon): add node-ops scoped macaroon preset (#7)

### DIFF
--- a/docs/adr/0001-governance-daemon.md
+++ b/docs/adr/0001-governance-daemon.md
@@ -1,0 +1,153 @@
+# ADR-0001 — Governance daemon for bounded node-ops execution
+
+- **Status:** Proposed
+- **Date:** 2026-06-25
+- **Issue:** #2 (blocks #8, #9, #10, #11, #12)
+
+## Context
+
+The node-ops thesis is **bounded execution**: every existing tool is either
+*safe-but-inert* (this kit's MCP server — read-only) or *active-but-unbounded*
+(abacus/LNDg/bos — admin macaroon, caps hardcoded in tool code, no audit, leaky or
+absent approval gates). Our wedge is the missing middle: an agent that can *act* on
+the node, but only inside cryptographically- and policy-bounded authority, with a
+real approval gate and an append-only audit trail.
+
+A hard constraint falls out of that: **enforcement must live below the LLM and
+outside any single agent turn.** The existing `lightning-mcp-server` is the wrong
+home for it — it is a **per-session, stdio subprocess** spawned by an MCP host
+(Claude Code). It has no persistent lifetime, so it cannot own a cumulative spend
+budget, a cooldown clock, a durable audit ledger, or a kill-switch that must stay
+effective even when no agent is connected. A prompt or an Agent Skill is weaker
+still (`allowed-tools` is advisory, not a security boundary).
+
+So we need a component that (a) outlives any MCP session, (b) is the *only* holder
+of write authority, and (c) enforces limits in code regardless of what the model
+asks.
+
+## Decision
+
+Add a long-lived **`node-ops-daemon`** (new Go binary) as the single enforcement
+boundary for all node-ops writes. The read-only MCP server is unchanged; new
+**write** MCP tools are thin clients that delegate to the daemon.
+
+```mermaid
+graph TD
+  LLM["LLM host (Claude Code)"] --> MCP["lightning-mcp-server<br/>(per-session, stdio)"]
+  MCP -->|read RPCs| LND
+  MCP -->|"execute_* (thin client)"| SOCK["unix socket<br/>~/.node-ops/daemon.sock"]
+  SOCK --> D
+  subgraph D["node-ops-daemon (long-lived)"]
+    POL["policy + limits engine"]
+    GATE["approval queue"]
+    KILL["kill-switch"]
+    LEDGER[("SQLite audit ledger")]
+  end
+  D -->|"node-ops scoped macaroon<br/>+ daemon request checks"| LND["watch-only lnd"]
+  LND -.signing.-> SIGNER["remote signer"]
+```
+
+### Sub-decisions
+
+1. **Placement — sidecar daemon, not in-process.** A separate process that runs
+   under systemd, independent of any MCP session. *Rejected:* an in-process package
+   in the MCP server (dies with the session; can't keep cumulative budgets, a
+   cooldown clock, or a kill-switch alive between connections).
+
+2. **Language — Go.** Matches the existing `lightning-mcp-server` module; reuses its
+   `lnrpc`/`routerrpc` client code and the macaroon-bakery output; one toolchain.
+
+3. **Transport — Unix-domain sockets.** MCP write clients use
+   `~/.node-ops/daemon.sock` (mode `0600`) with length-prefixed JSON
+   request/response (gRPC is an acceptable later swap). Operator approvals use a
+   separate operator-only socket/credential boundary. Local only — never a TCP port.
+   The MCP write tool sends `{action, params}`; the daemon returns
+   `{status, request_id, result|reason}`.
+
+4. **The daemon is the only holder of write authority.** It loads the **`node-ops`
+   scoped macaroon** (issue #7 — `UpdateChannelPolicy` + the minimum router RPCs
+   needed for circular rebalances, *not* admin) and the watch-only node connection.
+   lnd's URI-scoped macaroons do **not** encode "self-pay only"; self-payment is a
+   daemon-enforced request invariant before any router RPC is called. The MCP server
+   and the agent never see a write-capable credential.
+
+5. **Config — TOML** at `~/.node-ops/config.toml`. Limits are enforced from this
+   file in code, not from the prompt:
+
+   ```toml
+   [node]
+   lnd_rpc      = "127.0.0.1:10009"
+   macaroon     = "~/.node-ops/node-ops.macaroon"   # scoped, from issue #7
+   tls_cert     = "~/.lnd/tls.cert"
+
+   [limits]                      # enforced at the execution boundary
+   daily_rebalance_budget_sat = 100000
+   max_fee_ppm_delta          = 100      # per single fee change
+   per_channel_cooldown       = "30m"
+   rebalance_max_fee_ppm      = 500
+
+   [approval]                    # gate covers ALL money-affecting actions
+   auto_execute_below_ppm_delta = 25     # <= this auto-executes within limits…
+   require_approval             = true   # …everything else queues for a human
+
+   [storage]
+   ledger = "~/.node-ops/ledger.db"      # SQLite
+   killswitch = "~/.node-ops/STOP"       # presence halts all execution
+
+   [operator]
+   approval_socket = "~/.node-ops/operator.sock"  # separate human/operator boundary
+   ```
+
+6. **Ledger — SQLite** (`modernc.org/sqlite`, pure-Go, no CGO), an **INSERT-only**
+   `actions` table (proposal, triggering signal, justification, approve/deny, result,
+   timestamps). *Rejected:* append-only JSONL — harder to query for the audit query
+   tool (#12); SQLite gives transactional durability **and** queryability in one file.
+
+7. **Approval — a pending queue, not a blocking prompt.** A money-affecting request
+   above the auto-execute threshold is persisted as `pending` and surfaced
+   conversationally; a human approves out-of-band through an operator-only surface
+   such as `node-ops approve <request_id>`. The daemon authenticates approvals on a
+   boundary unavailable to the MCP host/agent, for example a separate Unix socket
+   guarded by peer credentials for an operator UID/group, or an equivalent
+   human-only credential. Approval is never exposed through the same model-callable
+   MCP session or the same execution socket as write requests. **All**
+   money-affecting actions pass the gate — closing the ungated-fee-set hole in
+   abacus/LNDg.
+
+8. **Kill-switch — independent of any LLM turn.** Presence of the `killswitch` file
+   (or a `--stop` daemon flag) makes the daemon reject every execution request
+   immediately, regardless of limits or approvals. `node-ops stop` / `node-ops resume`
+   toggle it.
+
+## Consequences
+
+**Positive**
+- Enforcement (budgets, cooldowns, kill-switch, audit) survives across sessions and
+  reboots — it is not tied to an agent turn.
+- A single, queryable source of truth for "what did the agent do and why" (#12).
+- Write authority is physically isolated: scoped macaroon lives only in the daemon;
+  combined with the remote signer, a compromised agent box still cannot move funds.
+
+**Negative / costs**
+- An extra long-lived process to supervise (a `node-ops-daemon.service` systemd unit
+  is part of #8).
+- IPC surfaces (execution + operator approval) to design and secure (`0600`,
+  peer-cred check, separate operator boundary).
+- Daemon lifecycle/versioning must stay in lockstep with the MCP write-tool client.
+
+**Unlocks**
+- #7 scoped macaroon → consumed by the daemon.
+- #8 daemon skeleton (limits + approval queue + ledger + kill-switch) implements this ADR.
+- #9 `execute_fee_set`, #10 `execute_rebalance` → thin MCP clients over the socket.
+- #11 limits hardening, #12 ledger query tool.
+
+## Alternatives considered
+
+| Option | Verdict | Why |
+|--------|---------|-----|
+| In-process limits in the MCP server | Rejected | Per-session stdio process; can't own persistent budgets/cooldown/kill-switch/audit. |
+| Enforcement in the Agent Skill / prompt | Rejected | A skill/prompt can't *enforce* anything; `allowed-tools` is advisory. Defeats the whole wedge. |
+| Append-only JSONL ledger | Rejected | Not queryable enough for #12; SQLite gives durability **and** queries in one file. |
+| TCP/gRPC over localhost now | Deferred | Unix socket is simpler and avoids any port exposure; gRPC can swap in later behind the same client interface. |
+
+Closes #2.

--- a/docs/dev-regtest.md
+++ b/docs/dev-regtest.md
@@ -1,0 +1,115 @@
+# Dev environment & regtest harness
+
+The development loop for working on `lightning-mcp-server` (and, going forward, the
+node-ops write path): **build the server, stand up a throwaway regtest litd node,
+and run the read tools against it.**
+
+> ⚠️ **Regtest only.** Never point experimental or write-path work at a mainnet
+> node. Regtest coins are worthless and the chain is disposable — that is the
+> entire point of this harness.
+
+## Prerequisites
+
+| Tool | Why | Notes |
+|------|-----|-------|
+| **Go 1.24+** | builds the MCP server | `go.mod` pins `go 1.24` (toolchain `go1.24.x`) |
+| **Docker + Compose** | runs the regtest `litd` + `bitcoind` stack | required for steps 2–6 |
+| `jq`, `gh` | helper scripting | |
+
+## 1. Build the MCP server
+
+```bash
+# via the skill script (compiles + installs to $GOPATH/bin)
+skills/lightning-mcp-server/scripts/install.sh
+
+# …or directly from the module
+cd lightning-mcp-server && go build -o ./lightning-mcp-server .
+```
+
+## 2. Bring up a regtest stack (litd + bitcoind)
+
+```bash
+skills/lnd/scripts/docker-start.sh --regtest
+# equivalently:
+#   docker compose -f skills/lnd/templates/docker-compose-regtest.yml up -d
+```
+
+This starts two containers:
+
+| Container | Exposes |
+|-----------|---------|
+| `litd` | lnd gRPC `:10009`, REST `:8080`, LiT HTTPS `:8443`, P2P `:9735` |
+| `litd-bitcoind` | Bitcoin Core regtest RPC `:18443`, ZMQ `:28332/:28333` |
+
+## 3. Create a wallet and fund the node
+
+```bash
+skills/lnd/scripts/create-wallet.sh --container litd --mode standalone
+
+# mine 101 blocks to a node address (101 = coinbase maturity + 1)
+docker exec litd-bitcoind bitcoin-cli -regtest -rpcuser=devuser -rpcpassword=devpass \
+  generatetoaddress 101 \
+  "$(docker exec litd lncli --network=regtest newaddress p2tr | jq -r '.address')"
+```
+
+## 4. Generate an LNC pairing phrase (read-only session)
+
+The MCP server connects over **Lightning Node Connect** using a one-time,
+BIP39-style **pairing phrase** minted by `litd`. Use a **read-only** session so the
+dev tunnel carries least privilege:
+
+```bash
+docker exec litd litcli --network=regtest sessions add \
+  --label dev-mcp --type readonly
+# copy the 10-word `pairing_secret_mnemonic` from the output
+```
+
+LNC routes both ends outbound to a mailbox relay (no inbound ports, no TLS certs,
+no macaroons on disk); the pairing phrase is single-use and the MCP server keeps
+only an ephemeral in-memory keypair for the session.
+
+## 5. Point the MCP server at regtest
+
+```bash
+# dev mode (insecure TLS for the local mailbox); writes lightning-mcp-server/.env
+skills/lightning-mcp-server/scripts/configure.sh --dev
+
+# then pass the pairing phrase and password to the `lnc_connect` tool.
+# Do not write the one-time pairing phrase to `.env` or any other file.
+```
+
+## 6. Run the read tools end-to-end
+
+Register the built server with an MCP host (e.g. Claude Code) or run it directly,
+then exercise the read tools and confirm live data comes back from the regtest
+node:
+
+- `lnc_get_info` → node pubkey, synced height, version
+- `lnc_list_channels`, `lnc_pending_channels`
+- `lnc_get_balance` → wallet and channel balances
+- `lnc_describe_graph`, `lnc_list_peers`
+
+All 18 tools are read-only — they query state and never mutate the node.
+
+## Teardown
+
+```bash
+docker compose -f skills/lnd/templates/docker-compose-regtest.yml down -v   # -v wipes volumes
+```
+
+## Two-node variant (for channel/payment testing)
+
+A second `litd` node (`bob`) is available behind a compose profile when you need a
+channel between two parties (e.g. routing / L402 tests):
+
+```bash
+docker compose -f skills/lnd/templates/docker-compose-regtest.yml --profile two-node up -d
+```
+
+---
+
+### See also
+- `skills/run-litd/SKILL.md` — full litd setup (Neutrino, bitcoind, remote signer)
+- `skills/lightning-mcp-server/SKILL.md` — MCP server build & configuration
+- `skills/lnc-app/SKILL.md` — Lightning Node Connect pairing details
+- `docs/mcp-server.md` — MCP transport / tool reference

--- a/goals/node-ops-continuation.md
+++ b/goals/node-ops-continuation.md
@@ -1,0 +1,259 @@
+# Node-Ops Continuation With Codex Shipper
+
+Continue the Lightning node-ops roadmap in `jerryfane/lightning-agent-tools`
+using the Codex-backed Gitmoot agent `shipper-codex`. First stabilize the
+existing PR stack for issues #1-#8, then continue issues #9-#15 with conservative
+parallelism. The intended outcome is a safe, gated node-ops system: read-only
+planning tools, a governance daemon, first write actions routed through approval
+and hard limits, an operator skill, and an end-to-end regtest proof.
+
+## Core Rules
+
+- Target repo: `jerryfane/lightning-agent-tools`.
+- Target base branch: `main`.
+- Runtime agent for all new work: `shipper-codex`.
+- Do not route new continuation work to the legacy Claude `shipper` agent.
+- Do not open or update upstream `lightninglabs/lightning-agent-tools` PRs unless
+  explicitly instructed by the human operator.
+- Preserve the existing untracked file `lightning-mcp-server/build.err`; do not
+  add, edit, delete, or commit it unless a later task explicitly requires it.
+- Use one branch and one PR per task or issue.
+- Every implementation PR must include tests or an explicit reason why only
+  static/docs validation applies.
+- Run `codex exec review --uncommitted` on every repo with uncommitted changes
+  before commit, and include the exact final raw review output in the PR body.
+- Use squash merge if the repo has no discoverable preferred merge method.
+- After each merge, update local `main`, verify the worktree is clean except for
+  intentionally ignored or pre-existing untracked files, and re-check remaining
+  PR mergeability.
+- If a task becomes safety-critical, order-dependent, or conflicted, stop
+  treating it as parallel and serialize it behind its dependency.
+
+## Before Starting
+
+Run and record these checks:
+
+```sh
+git status --short --branch
+git remote -v
+gh auth status
+gitmoot agent doctor shipper-codex
+gitmoot daemon status
+gitmoot status --repo jerryfane/lightning-agent-tools
+```
+
+If the repo is not on `main`, the remote no longer resolves to
+`jerryfane/lightning-agent-tools`, GitHub auth fails, or there are unrelated
+tracked changes, stop and report the blocker.
+
+## Parallel Strategy
+
+- Stabilization comes first. Do not start issues #9-#15 until PR #23 for issue
+  #8 is merged into `jerryfane/lightning-agent-tools/main`.
+- During stabilization, merge overlapping MCP tool PRs one at a time because
+  #18, #19, #20, and #22 all touch
+  `lightning-mcp-server/internal/services/manager.go`.
+- After #23 lands, issue #11 and issue #12 may run in parallel if their file
+  ownership remains cleanly separated.
+- Issue #13 may run in parallel with daemon hardening if it only consumes
+  read-only `node_health` output and does not change write-path daemon logic.
+- Issue #9 and issue #10 are safety-critical write paths. Do not implement both
+  in the same branch. Prefer #9 first, then #10, unless #11 must land first to
+  make the execution boundary safe.
+- Issue #14 starts only after #9 lands.
+- Issue #15 runs last after #10, #12, and #14 are merged.
+
+## Implementation Tasks
+
+### Task 1: Stabilize And Merge Existing PR Stack (#16-#23)
+
+Review and merge the already-open fork PRs in this repo:
+
+1. #16 `docs: dev environment + regtest harness (#1)`
+2. #17 `docs: ADR-0001 governance daemon architecture (#2)`
+3. #18 `propose_fees` for #3
+4. #19 `propose_rebalance` for #4
+5. #20 `node_health` for #6
+6. #22 `propose_channel_actions` for #5
+7. #21 `node-ops scoped macaroon preset` for #7
+8. #23 `governance daemon skeleton` for #8
+
+Acceptance criteria:
+
+- Each PR is reviewed with Codex before merge.
+- Relevant tests pass for each PR. For Go MCP changes, run tests in
+  `lightning-mcp-server`. For `node-ops-daemon`, run `go test ./...` and
+  `go build ./...` in that module.
+- If a PR is stale but otherwise correct, rebase/update it against current
+  `main`, rerun checks, and merge.
+- If a PR has a real content conflict or failing test, create a focused fix on
+  that PR branch, rerun checks, and continue.
+- Close or supersede duplicate/stale blocked Gitmoot task records only if
+  Gitmoot requires it to proceed; otherwise leave historical records untouched.
+
+Suggested PR/merge notes:
+
+- Mention the original issue number closed by each PR.
+- Record PR URL and merge commit hash in the final Gitmoot result.
+
+### Task 2: Harden Limits Engine Persistence (#11)
+
+Implement issue #11 after #23 is merged.
+
+Acceptance criteria:
+
+- Daily budgets, per-channel cooldowns, and kill-switch state are enforced at
+  the daemon execution boundary, not in prompts.
+- Required state survives daemon restart.
+- Tests cover budget exhaustion, cooldown enforcement, and restart persistence.
+- The implementation does not execute real mainnet writes.
+
+Suggested commit message:
+
+```text
+feat(daemon): persist node-ops limits state
+```
+
+### Task 3: Add Audit Ledger Query Surface (#12)
+
+Implement issue #12 after #23 is merged. This may run in parallel with Task 2 if
+it does not modify the same daemon files.
+
+Acceptance criteria:
+
+- Every proposal, approval or denial, execution result, and failure is recorded
+  in the append-only ledger.
+- Add a read-only query surface for the ledger, preferably through the MCP server
+  if it matches repo patterns.
+- Tests prove entries are append-only and queryable.
+
+Suggested commit message:
+
+```text
+feat(daemon): expose node-ops audit ledger query
+```
+
+### Task 4: Implement Gated Fee-Set Execution (#9)
+
+Implement issue #9 after #23 is merged. If Task 2 changes the execution-boundary
+limits contract, wait for Task 2 before implementing this task.
+
+Acceptance criteria:
+
+- Add MCP `execute_fee_set` support that routes through the daemon.
+- Enforce ppm delta cap, cooldown, budget, approval, kill-switch, and audit log
+  before any write execution.
+- Execute `UpdateChannelPolicy` only through the scoped node-ops macaroon.
+- Tests and/or regtest smoke prove: within-cap approved fee set succeeds,
+  over-cap fee set is rejected, denied approval does not execute, and every path
+  creates the expected audit entry.
+- Mainnet execution must remain impossible in automated tests.
+
+Suggested commit message:
+
+```text
+feat(mcp): add gated execute_fee_set
+```
+
+### Task 5: Implement Gated Rebalance Execution (#10)
+
+Implement issue #10 after #23 is merged and after any required limits-boundary
+work from Task 2.
+
+Acceptance criteria:
+
+- Add gated circular rebalance execution via `bos rebalance` or `SendToRouteV2`.
+- Enforce daily sat budget, max ppm, approval, kill-switch, and audit logging.
+- Tests and/or regtest smoke prove approved in-cap rebalance succeeds and
+  over-cap rebalance is rejected.
+- Keep this branch separate from Task 4.
+
+Suggested commit message:
+
+```text
+feat(daemon): add gated rebalance execution
+```
+
+### Task 6: Add Background Monitoring And Push Alerts (#13)
+
+Implement issue #13 after #20/#6 is merged. This may run in parallel with Tasks
+2-5 only if it remains read-only and does not alter write-path daemon behavior.
+
+Acceptance criteria:
+
+- Background monitor polls or subscribes to `node_health`.
+- Simulated force-close, peer, or health degradation on regtest creates a push
+  alert through a configurable channel or conversational surface.
+- Tests cover alert triggering and de-duplication or cooldown behavior.
+
+Suggested commit message:
+
+```text
+feat(mcp): add node health alert monitor
+```
+
+### Task 7: Add Node-Ops Agent Skill (#14)
+
+Implement issue #14 after Task 4 is merged.
+
+Acceptance criteria:
+
+- Add `skills/node-ops/SKILL.md` with frontmatter and a propose -> approve ->
+  execute operator playbook.
+- Add skill scripts for observe, propose, and execute paths that call the daemon
+  or MCP surfaces; they must not call `lncli` directly for writes.
+- Run `skills-ref validate ./skills/node-ops` if available. If unavailable,
+  document the missing validator and run a structural/manual validation pass.
+
+Suggested commit message:
+
+```text
+feat(skill): add node-ops operator skill
+```
+
+### Task 8: End-To-End Regtest Integration And Docs (#15)
+
+Implement issue #15 last, after Tasks 5, 3, and 7 are merged.
+
+Acceptance criteria:
+
+- Fresh regtest flow documents and proves: setup -> bake node-ops macaroon ->
+  run daemon -> propose -> approve -> execute fee-set -> execute rebalance ->
+  query audit log.
+- README or quickstart documents the full operator path.
+- The final smoke test is reproducible from the documented commands.
+
+Suggested commit message:
+
+```text
+docs(node-ops): add end-to-end regtest quickstart
+```
+
+## Gitmoot Execution Commands
+
+After this goal is imported, execute with:
+
+```sh
+gitmoot orchestrate shipper-codex --repo jerryfane/lightning-agent-tools "Execute the node-ops continuation goal from goals/node-ops-continuation.md. Start with Task 1 stabilization. After PR #23 is merged, fan out only the tasks marked safe for parallel execution. Keep safety-critical write paths serialized when their limits or execution boundaries overlap. Report PR URLs, merge commits, checks run, and any blockers."
+```
+
+For direct task execution, use:
+
+```sh
+gitmoot task run <task-id> --repo jerryfane/lightning-agent-tools --owner shipper-codex --base main
+```
+
+## Final Report Requirements
+
+Return a `gitmoot_result` JSON object with:
+
+- `decision`: `implemented`, `blocked`, or `failed`.
+- `summary`: concise outcome.
+- `changes_made`: goal tasks completed and merged.
+- `tests_run`: checks by task.
+- `needs`: human actions, skipped checks, or remaining blockers.
+- `delegations`: any parallel subtasks launched and their final status.
+
+Also include each completed task's branch, PR URL, merge status, and merged
+commit hash. Do not claim interactive `/review` is clean; say
+`codex exec review is clean; ready for manual /review.`

--- a/lightning-mcp-server/internal/services/manager.go
+++ b/lightning-mcp-server/internal/services/manager.go
@@ -35,6 +35,7 @@ type Manager struct {
 	onchainService    *tools.OnChainService
 	peerService       *tools.PeerService
 	nodeService       *tools.NodeService
+	feeService        *tools.FeeService
 }
 
 // NewManager creates a new service manager for read-only operations.
@@ -60,6 +61,7 @@ func (m *Manager) InitializeServices() {
 	m.onchainService = tools.NewOnChainService(nil)
 	m.peerService = tools.NewPeerService(nil)
 	m.nodeService = tools.NewNodeService(nil)
+	m.feeService = tools.NewFeeService(nil)
 
 	m.logger.Info("Read-only services initialized successfully")
 }
@@ -128,6 +130,10 @@ func (m *Manager) RegisterTools(mcpServer interfaces.MCPServer) error {
 	register(m.nodeService.GetInfoTool(),
 		m.nodeService.HandleGetInfo)
 
+	// Fee proposal tool - read-only operations.
+	register(m.feeService.ProposeFeesTool(),
+		m.feeService.HandleProposeFees)
+
 	m.logger.Info("Read-only MCP tools registered",
 		zap.Int("total_tools", registrations))
 	return nil
@@ -149,6 +155,7 @@ func (m *Manager) onLNCConnectionEstablished(conn *grpc.ClientConn) {
 	m.onchainService.LightningClient = m.lightningClient
 	m.peerService.LightningClient = m.lightningClient
 	m.nodeService.LightningClient = m.lightningClient
+	m.feeService.LightningClient = m.lightningClient
 
 	logger.Info("All read-only services updated with new connection")
 }

--- a/lightning-mcp-server/internal/services/manager.go
+++ b/lightning-mcp-server/internal/services/manager.go
@@ -28,16 +28,17 @@ type Manager struct {
 	lightningClient lnrpc.LightningClient
 
 	// Services - read-only operations only.
-	connectionService *tools.ConnectionService
-	invoiceService    *tools.InvoiceService
-	channelService    *tools.ChannelService
-	paymentService    *tools.PaymentService
-	onchainService    *tools.OnChainService
-	peerService       *tools.PeerService
-	nodeService       *tools.NodeService
-	healthService     *tools.HealthService
-	rebalanceService  *tools.RebalanceService
-	feeService        *tools.FeeService
+	connectionService     *tools.ConnectionService
+	invoiceService        *tools.InvoiceService
+	channelService        *tools.ChannelService
+	channelActionsService *tools.ChannelActionsService
+	paymentService        *tools.PaymentService
+	onchainService        *tools.OnChainService
+	peerService           *tools.PeerService
+	nodeService           *tools.NodeService
+	healthService         *tools.HealthService
+	rebalanceService      *tools.RebalanceService
+	feeService            *tools.FeeService
 }
 
 // NewManager creates a new service manager for read-only operations.
@@ -59,6 +60,7 @@ func (m *Manager) InitializeServices() {
 	// Initialize all read-only services with nil clients.
 	m.invoiceService = tools.NewInvoiceService(nil)
 	m.channelService = tools.NewChannelService(nil)
+	m.channelActionsService = tools.NewChannelActionsService(nil)
 	m.paymentService = tools.NewPaymentService(nil)
 	m.onchainService = tools.NewOnChainService(nil)
 	m.peerService = tools.NewPeerService(nil)
@@ -105,6 +107,8 @@ func (m *Manager) RegisterTools(mcpServer interfaces.MCPServer) error {
 		m.channelService.HandleListChannels)
 	register(m.channelService.PendingChannelsTool(),
 		m.channelService.HandlePendingChannels)
+	register(m.channelActionsService.ProposeChannelActionsTool(),
+		m.channelActionsService.HandleProposeChannelActions)
 
 	// Payment tools - read-only operations.
 	register(m.paymentService.ListPaymentsTool(),
@@ -163,6 +167,7 @@ func (m *Manager) onLNCConnectionEstablished(conn *grpc.ClientConn) {
 	// Update existing read-only services with new connection.
 	m.invoiceService.LightningClient = m.lightningClient
 	m.channelService.LightningClient = m.lightningClient
+	m.channelActionsService.LightningClient = m.lightningClient
 	m.paymentService.LightningClient = m.lightningClient
 	m.onchainService.LightningClient = m.lightningClient
 	m.peerService.LightningClient = m.lightningClient

--- a/lightning-mcp-server/internal/services/manager.go
+++ b/lightning-mcp-server/internal/services/manager.go
@@ -35,6 +35,7 @@ type Manager struct {
 	onchainService    *tools.OnChainService
 	peerService       *tools.PeerService
 	nodeService       *tools.NodeService
+	healthService     *tools.HealthService
 	rebalanceService  *tools.RebalanceService
 	feeService        *tools.FeeService
 }
@@ -62,6 +63,7 @@ func (m *Manager) InitializeServices() {
 	m.onchainService = tools.NewOnChainService(nil)
 	m.peerService = tools.NewPeerService(nil)
 	m.nodeService = tools.NewNodeService(nil)
+	m.healthService = tools.NewHealthService(nil)
 	m.rebalanceService = tools.NewRebalanceService(nil)
 	m.feeService = tools.NewFeeService(nil)
 
@@ -132,6 +134,10 @@ func (m *Manager) RegisterTools(mcpServer interfaces.MCPServer) error {
 	register(m.nodeService.GetInfoTool(),
 		m.nodeService.HandleGetInfo)
 
+	// Health tools - read-only operations.
+	register(m.healthService.NodeHealthTool(),
+		m.healthService.HandleNodeHealth)
+
 	// Rebalance tools - read-only proposal only, no funds movement.
 	register(m.rebalanceService.ProposeRebalanceTool(),
 		m.rebalanceService.HandleProposeRebalance)
@@ -161,6 +167,7 @@ func (m *Manager) onLNCConnectionEstablished(conn *grpc.ClientConn) {
 	m.onchainService.LightningClient = m.lightningClient
 	m.peerService.LightningClient = m.lightningClient
 	m.nodeService.LightningClient = m.lightningClient
+	m.healthService.LightningClient = m.lightningClient
 	m.rebalanceService.LightningClient = m.lightningClient
 	m.feeService.LightningClient = m.lightningClient
 

--- a/lightning-mcp-server/internal/services/manager.go
+++ b/lightning-mcp-server/internal/services/manager.go
@@ -35,6 +35,7 @@ type Manager struct {
 	onchainService    *tools.OnChainService
 	peerService       *tools.PeerService
 	nodeService       *tools.NodeService
+	rebalanceService  *tools.RebalanceService
 	feeService        *tools.FeeService
 }
 
@@ -61,6 +62,7 @@ func (m *Manager) InitializeServices() {
 	m.onchainService = tools.NewOnChainService(nil)
 	m.peerService = tools.NewPeerService(nil)
 	m.nodeService = tools.NewNodeService(nil)
+	m.rebalanceService = tools.NewRebalanceService(nil)
 	m.feeService = tools.NewFeeService(nil)
 
 	m.logger.Info("Read-only services initialized successfully")
@@ -130,6 +132,10 @@ func (m *Manager) RegisterTools(mcpServer interfaces.MCPServer) error {
 	register(m.nodeService.GetInfoTool(),
 		m.nodeService.HandleGetInfo)
 
+	// Rebalance tools - read-only proposal only, no funds movement.
+	register(m.rebalanceService.ProposeRebalanceTool(),
+		m.rebalanceService.HandleProposeRebalance)
+
 	// Fee proposal tool - read-only operations.
 	register(m.feeService.ProposeFeesTool(),
 		m.feeService.HandleProposeFees)
@@ -155,6 +161,7 @@ func (m *Manager) onLNCConnectionEstablished(conn *grpc.ClientConn) {
 	m.onchainService.LightningClient = m.lightningClient
 	m.peerService.LightningClient = m.lightningClient
 	m.nodeService.LightningClient = m.lightningClient
+	m.rebalanceService.LightningClient = m.lightningClient
 	m.feeService.LightningClient = m.lightningClient
 
 	logger.Info("All read-only services updated with new connection")

--- a/lightning-mcp-server/tools/channel_actions.go
+++ b/lightning-mcp-server/tools/channel_actions.go
@@ -1,0 +1,338 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	defaultLookbackDays           = 30
+	maxLookbackDays               = 365
+	channelActionsHistoryPageSize = uint32(50000)
+	minChannelCountForOpen        = 5
+	defaultCloseCandidates        = 10
+	maxCloseCandidates            = 50
+	defaultOpenCandidates         = 5
+	maxOpenCandidates             = 20
+)
+
+// ChannelActionsService proposes read-only channel open/close candidates.
+type ChannelActionsService struct {
+	LightningClient lnrpc.LightningClient
+}
+
+// NewChannelActionsService creates a new channel actions service.
+func NewChannelActionsService(
+	client lnrpc.LightningClient) *ChannelActionsService {
+
+	return &ChannelActionsService{LightningClient: client}
+}
+
+// ProposeChannelActionsTool returns the MCP tool definition.
+func (s *ChannelActionsService) ProposeChannelActionsTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "lnc_propose_channel_actions",
+		Description: "Propose read-only channel open/close candidates. " +
+			"Flags unproductive or inactive channels as close candidates " +
+			"and suggests well-connected peers as open candidates based on " +
+			"forwarding history and the network graph. " +
+			"Read-only — no changes are made to the node.",
+		InputSchema: ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"lookback_days": map[string]any{
+					"type": "integer",
+					"description": "Days to look back for forwarding " +
+						"activity (default 30)",
+					"minimum": 1,
+					"maximum": 365,
+				},
+				"max_close_candidates": map[string]any{
+					"type": "integer",
+					"description": "Max close candidates to return " +
+						"(default 10)",
+					"minimum": 1,
+					"maximum": 50,
+				},
+				"max_open_candidates": map[string]any{
+					"type": "integer",
+					"description": "Max open candidates to return " +
+						"(default 5)",
+					"minimum": 1,
+					"maximum": 20,
+				},
+			},
+		},
+	}
+}
+
+// HandleProposeChannelActions handles the propose channel actions request.
+func (s *ChannelActionsService) HandleProposeChannelActions(
+	ctx context.Context,
+	request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+
+	args := requestArguments(request)
+
+	if s.LightningClient == nil {
+		return newToolResultError(
+			"Not connected to Lightning node. " +
+				"Use lnc_connect first."), nil
+	}
+
+	lookbackDays := boundedIntArg(
+		args, "lookback_days", defaultLookbackDays, 1,
+		maxLookbackDays,
+	)
+	maxClose := boundedIntArg(
+		args, "max_close_candidates", defaultCloseCandidates, 1,
+		maxCloseCandidates,
+	)
+	maxOpen := boundedIntArg(
+		args, "max_open_candidates", defaultOpenCandidates, 1,
+		maxOpenCandidates,
+	)
+
+	// Fetch all open channels.
+	chanResp, err := s.LightningClient.ListChannels(
+		ctx, &lnrpc.ListChannelsRequest{},
+	)
+	if err != nil {
+		return newToolResultError(
+			"Failed to list channels: " + err.Error()), nil
+	}
+
+	now := uint64(time.Now().Unix())
+	startTime := now - uint64(lookbackDays)*86400
+
+	activeFwdChans := make(map[uint64]bool)
+	forwardingEvents := 0
+	var offset uint32
+	for {
+		fwdResp, err := s.LightningClient.ForwardingHistory(
+			ctx, &lnrpc.ForwardingHistoryRequest{
+				StartTime:    startTime,
+				EndTime:      now,
+				NumMaxEvents: channelActionsHistoryPageSize,
+				IndexOffset:  offset,
+			},
+		)
+		if err != nil {
+			return newToolResultError(
+				"Failed to get forwarding history: " +
+					err.Error()), nil
+		}
+
+		forwardingEvents += len(fwdResp.ForwardingEvents)
+		for _, evt := range fwdResp.ForwardingEvents {
+			activeFwdChans[evt.ChanIdIn] = true
+			activeFwdChans[evt.ChanIdOut] = true
+		}
+		if uint32(len(fwdResp.ForwardingEvents)) <
+			channelActionsHistoryPageSize {
+			break
+		}
+		if fwdResp.LastOffsetIndex <= offset {
+			return newToolResultError(
+				"Failed to paginate forwarding history: " +
+					"non-advancing offset"), nil
+		}
+		offset = fwdResp.LastOffsetIndex
+	}
+
+	noFwdReason := "no_forwards_in_" + strconv.Itoa(lookbackDays) + "d"
+
+	// Score and collect close candidates.
+	type closeEntry struct {
+		ch      *lnrpc.Channel
+		reasons []string
+		score   int
+	}
+	var closeEntries []closeEntry
+	existingPeers := make(map[string]bool)
+
+	for _, ch := range chanResp.Channels {
+		existingPeers[ch.RemotePubkey] = true
+
+		var reasons []string
+		score := 0
+
+		if !ch.Active {
+			reasons = append(reasons, "inactive_channel")
+			score += 3
+		}
+		if ch.NumUpdates == 0 &&
+			ch.TotalSatoshisSent == 0 &&
+			ch.TotalSatoshisReceived == 0 {
+			reasons = append(reasons, "zero_activity")
+			score += 2
+		}
+		if !activeFwdChans[ch.ChanId] {
+			reasons = append(reasons, noFwdReason)
+			score += 1
+		}
+
+		if len(reasons) > 0 {
+			closeEntries = append(closeEntries, closeEntry{
+				ch:      ch,
+				reasons: reasons,
+				score:   score,
+			})
+		}
+	}
+
+	sort.Slice(closeEntries, func(i, j int) bool {
+		if closeEntries[i].score == closeEntries[j].score {
+			return closeEntries[i].ch.ChanId < closeEntries[j].ch.ChanId
+		}
+		return closeEntries[i].score > closeEntries[j].score
+	})
+	if len(closeEntries) > maxClose {
+		closeEntries = closeEntries[:maxClose]
+	}
+
+	closeResult := make([]map[string]any, len(closeEntries))
+	for i, e := range closeEntries {
+		closeResult[i] = map[string]any{
+			"chan_id":         strconv.FormatUint(e.ch.ChanId, 10),
+			"channel_point":   e.ch.ChannelPoint,
+			"remote_pubkey":   e.ch.RemotePubkey,
+			"capacity":        e.ch.Capacity,
+			"local_balance":   e.ch.LocalBalance,
+			"remote_balance":  e.ch.RemoteBalance,
+			"active":          e.ch.Active,
+			"num_updates":     e.ch.NumUpdates,
+			"total_sats_sent": e.ch.TotalSatoshisSent,
+			"total_sats_recv": e.ch.TotalSatoshisReceived,
+			"reasons":         e.reasons,
+		}
+	}
+
+	// Open candidates: well-connected nodes not already peered with.
+	openResult, openErr := buildOpenCandidates(
+		ctx, s.LightningClient, existingPeers, maxOpen,
+	)
+
+	response := map[string]any{
+		"close_candidates":     closeResult,
+		"open_candidates":      openResult,
+		"analysis_window_days": lookbackDays,
+		"total_channels":       len(chanResp.Channels),
+		"forwarding_events":    forwardingEvents,
+	}
+	if openErr != nil {
+		response["open_candidates_error"] = openErr.Error()
+	}
+
+	return newToolResultJSON(response), nil
+}
+
+// buildOpenCandidates returns well-connected nodes from the network graph
+// that the local node does not already have channels with.
+func buildOpenCandidates(
+	ctx context.Context,
+	client lnrpc.LightningClient,
+	existingPeers map[string]bool,
+	maxCandidates int,
+) ([]map[string]any, error) {
+
+	info, err := client.GetInfo(ctx, &lnrpc.GetInfoRequest{})
+	if err != nil {
+		return []map[string]any{}, err
+	}
+
+	graph, err := client.DescribeGraph(
+		ctx, &lnrpc.ChannelGraphRequest{IncludeUnannounced: false},
+	)
+	if err != nil {
+		return []map[string]any{}, err
+	}
+
+	nodeChanCount := make(map[string]int)
+	nodeCapacity := make(map[string]int64)
+	for _, edge := range graph.Edges {
+		nodeChanCount[edge.Node1Pub]++
+		nodeChanCount[edge.Node2Pub]++
+		nodeCapacity[edge.Node1Pub] += edge.Capacity
+		nodeCapacity[edge.Node2Pub] += edge.Capacity
+	}
+
+	aliasMap := make(map[string]string)
+	for _, node := range graph.Nodes {
+		aliasMap[node.PubKey] = node.Alias
+	}
+
+	excludedPeers := make(map[string]bool, len(existingPeers)+1)
+	for peer := range existingPeers {
+		excludedPeers[peer] = true
+	}
+	excludedPeers[info.IdentityPubkey] = true
+
+	type candidate struct {
+		pubKey   string
+		alias    string
+		numChans int
+		capacity int64
+	}
+
+	var candidates []candidate
+	for pubKey, numChans := range nodeChanCount {
+		if excludedPeers[pubKey] || numChans < minChannelCountForOpen {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			pubKey:   pubKey,
+			alias:    aliasMap[pubKey],
+			numChans: numChans,
+			capacity: nodeCapacity[pubKey],
+		})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].numChans != candidates[j].numChans {
+			return candidates[i].numChans > candidates[j].numChans
+		}
+		if candidates[i].capacity != candidates[j].capacity {
+			return candidates[i].capacity > candidates[j].capacity
+		}
+		return candidates[i].pubKey < candidates[j].pubKey
+	})
+	if len(candidates) > maxCandidates {
+		candidates = candidates[:maxCandidates]
+	}
+
+	result := make([]map[string]any, len(candidates))
+	for i, c := range candidates {
+		result[i] = map[string]any{
+			"peer_pubkey":    c.pubKey,
+			"alias":          c.alias,
+			"num_channels":   c.numChans,
+			"total_capacity": c.capacity,
+			"reasons":        []string{"well_connected_node"},
+		}
+	}
+	return result, nil
+}
+
+func boundedIntArg(args map[string]any, key string, defaultValue, minValue,
+	maxValue int) int {
+
+	value := defaultValue
+	if raw, ok := args[key].(float64); ok {
+		value = int(raw)
+	}
+	if value < minValue {
+		return minValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}

--- a/lightning-mcp-server/tools/channel_actions_test.go
+++ b/lightning-mcp-server/tools/channel_actions_test.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type mockChannelActionsClient struct {
+	lnrpc.LightningClient
+	channels     []*lnrpc.Channel
+	fwdResponses []*lnrpc.ForwardingHistoryResponse
+	fwdRequests  []*lnrpc.ForwardingHistoryRequest
+	info         *lnrpc.GetInfoResponse
+	graph        *lnrpc.ChannelGraph
+	graphErr     error
+}
+
+func (m *mockChannelActionsClient) ListChannels(context.Context,
+	*lnrpc.ListChannelsRequest,
+	...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+
+	return &lnrpc.ListChannelsResponse{Channels: m.channels}, nil
+}
+
+func (m *mockChannelActionsClient) GetInfo(context.Context,
+	*lnrpc.GetInfoRequest,
+	...grpc.CallOption) (*lnrpc.GetInfoResponse, error) {
+
+	if m.info != nil {
+		return m.info, nil
+	}
+	return &lnrpc.GetInfoResponse{IdentityPubkey: "local"}, nil
+}
+
+func (m *mockChannelActionsClient) ForwardingHistory(_ context.Context,
+	req *lnrpc.ForwardingHistoryRequest,
+	_ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+
+	m.fwdRequests = append(m.fwdRequests, &lnrpc.ForwardingHistoryRequest{
+		StartTime:    req.StartTime,
+		EndTime:      req.EndTime,
+		NumMaxEvents: req.NumMaxEvents,
+		IndexOffset:  req.IndexOffset,
+	})
+	idx := len(m.fwdRequests) - 1
+	if idx < len(m.fwdResponses) {
+		return m.fwdResponses[idx], nil
+	}
+	return &lnrpc.ForwardingHistoryResponse{}, nil
+}
+
+func (m *mockChannelActionsClient) DescribeGraph(context.Context,
+	*lnrpc.ChannelGraphRequest,
+	...grpc.CallOption) (*lnrpc.ChannelGraph, error) {
+
+	if m.graphErr != nil {
+		return nil, m.graphErr
+	}
+	if m.graph != nil {
+		return m.graph, nil
+	}
+	return &lnrpc.ChannelGraph{}, nil
+}
+
+func makeChannelActionsReq(t *testing.T,
+	args map[string]any) *mcp.CallToolRequest {
+
+	t.Helper()
+	b, err := json.Marshal(args)
+	require.NoError(t, err)
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Arguments: b},
+	}
+}
+
+func TestChannelActionsService_ForwardingHistoryPagination(t *testing.T) {
+	firstPage := make(
+		[]*lnrpc.ForwardingEvent, channelActionsHistoryPageSize,
+	)
+	for i := range firstPage {
+		firstPage[i] = &lnrpc.ForwardingEvent{ChanIdIn: 99}
+	}
+	stub := &mockChannelActionsClient{
+		channels: []*lnrpc.Channel{{
+			ChanId: 2, Active: true, NumUpdates: 1,
+			TotalSatoshisSent: 1, RemotePubkey: "peer",
+		}},
+		fwdResponses: []*lnrpc.ForwardingHistoryResponse{
+			{
+				ForwardingEvents: firstPage,
+				LastOffsetIndex:  channelActionsHistoryPageSize,
+			},
+			{
+				ForwardingEvents: []*lnrpc.ForwardingEvent{{
+					ChanIdOut: 2,
+				}},
+				LastOffsetIndex: channelActionsHistoryPageSize,
+			},
+		},
+	}
+	svc := NewChannelActionsService(stub)
+
+	result, err := svc.HandleProposeChannelActions(
+		context.Background(), makeChannelActionsReq(t, nil),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	require.Len(t, stub.fwdRequests, 2)
+	assert.Equal(t, uint32(0), stub.fwdRequests[0].IndexOffset)
+	assert.Equal(t, uint32(channelActionsHistoryPageSize),
+		stub.fwdRequests[1].IndexOffset)
+
+	out := unmarshalResult(t, result)
+	assert.Equal(t, float64(channelActionsHistoryPageSize+1),
+		out["forwarding_events"])
+	assert.Empty(t, out["close_candidates"].([]any))
+}
+
+func TestChannelActionsService_DescribeGraphErrorKeepsCloseCandidates(
+	t *testing.T) {
+
+	stub := &mockChannelActionsClient{
+		channels: []*lnrpc.Channel{{
+			ChanId: 1, Active: false, RemotePubkey: "peer",
+		}},
+		graphErr: errors.New("graph unavailable"),
+	}
+	svc := NewChannelActionsService(stub)
+
+	result, err := svc.HandleProposeChannelActions(
+		context.Background(), makeChannelActionsReq(t, map[string]any{
+			"lookback_days":        999,
+			"max_close_candidates": 999,
+			"max_open_candidates":  999,
+		}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := unmarshalResult(t, result)
+	assert.Equal(t, float64(maxLookbackDays),
+		out["analysis_window_days"])
+	assert.Contains(t, out["open_candidates_error"], "graph unavailable")
+	assert.Empty(t, out["open_candidates"].([]any))
+	require.Len(t, out["close_candidates"].([]any), 1)
+}
+
+func TestChannelActionsService_OpenCandidatesExcludeLocalNode(t *testing.T) {
+	stub := &mockChannelActionsClient{
+		info: &lnrpc.GetInfoResponse{IdentityPubkey: "local"},
+		graph: &lnrpc.ChannelGraph{
+			Nodes: []*lnrpc.LightningNode{
+				{PubKey: "local", Alias: "local-node"},
+				{PubKey: "candidate", Alias: "candidate-node"},
+			},
+			Edges: []*lnrpc.ChannelEdge{
+				{Node1Pub: "local", Node2Pub: "a", Capacity: 1},
+				{Node1Pub: "local", Node2Pub: "b", Capacity: 1},
+				{Node1Pub: "local", Node2Pub: "c", Capacity: 1},
+				{Node1Pub: "local", Node2Pub: "d", Capacity: 1},
+				{Node1Pub: "local", Node2Pub: "e", Capacity: 1},
+				{Node1Pub: "candidate", Node2Pub: "a", Capacity: 2},
+				{Node1Pub: "candidate", Node2Pub: "b", Capacity: 2},
+				{Node1Pub: "candidate", Node2Pub: "c", Capacity: 2},
+				{Node1Pub: "candidate", Node2Pub: "d", Capacity: 2},
+				{Node1Pub: "candidate", Node2Pub: "e", Capacity: 2},
+			},
+		},
+	}
+	svc := NewChannelActionsService(stub)
+
+	result, err := svc.HandleProposeChannelActions(
+		context.Background(), makeChannelActionsReq(t, nil),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := unmarshalResult(t, result)
+	candidates := out["open_candidates"].([]any)
+	require.Len(t, candidates, 1)
+	candidate := candidates[0].(map[string]any)
+	assert.Equal(t, "candidate", candidate["peer_pubkey"])
+}

--- a/lightning-mcp-server/tools/fees.go
+++ b/lightning-mcp-server/tools/fees.go
@@ -31,15 +31,15 @@ func (s *FeeService) ProposeFeesTool() *mcp.Tool {
 		Name: "lnc_propose_fees",
 		Description: "Analyse routing history and channel balances to propose " +
 			"fee-rate adjustments per channel. Read-only: uses " +
-			"ForwardingHistory and ListChannels only.",
+			"ForwardingHistory, FeeReport, and ListChannels only.",
 		InputSchema: ToolInputSchema{
 			Type: "object",
 			Properties: map[string]any{
 				"days": map[string]any{
-					"type":        "number",
-					"description": "Lookback window in days for forwarding history (default 7, max 90)",
-					"minimum":     1,
-					"maximum":     90,
+					"type":             "number",
+					"description":      "Lookback window in days for forwarding history (default 7, max 90)",
+					"exclusiveMinimum": 0,
+					"maximum":          90,
 				},
 				"min_fee_ppm": map[string]any{
 					"type":        "number",
@@ -147,6 +147,19 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 			"Failed to list channels: " + err.Error()), nil
 	}
 
+	feeReport, err := s.LightningClient.FeeReport(
+		ctx, &lnrpc.FeeReportRequest{},
+	)
+	if err != nil {
+		return newToolResultError(
+			"Failed to fetch fee report: " + err.Error()), nil
+	}
+	currentFees := make(map[uint64]*lnrpc.ChannelFeeReport,
+		len(feeReport.ChannelFees))
+	for _, fee := range feeReport.ChannelFees {
+		currentFees[fee.ChanId] = fee
+	}
+
 	proposals := make([]map[string]any, 0, len(channels.Channels))
 	for _, ch := range channels.Channels {
 		localRatio := float64(0)
@@ -171,8 +184,15 @@ func (s *FeeService) HandleProposeFees(ctx context.Context,
 			"remote_balance":   ch.RemoteBalance,
 			"local_ratio":      round2(localRatio),
 			"forwards_out":     forwards,
+			"current_fee_ppm":  nil,
 			"proposed_fee_ppm": proposedPPM,
+			"fee_delta_ppm":    nil,
 			"reason":           feeReason(localRatio, forwards),
+		}
+		if fee := currentFees[ch.ChanId]; fee != nil {
+			entry["current_fee_ppm"] = fee.FeePerMil
+			entry["current_base_fee_msat"] = fee.BaseFeeMsat
+			entry["fee_delta_ppm"] = proposedPPM - fee.FeePerMil
 		}
 		if st != nil {
 			entry["amt_routed_msat"] = st.amtOutMsat

--- a/lightning-mcp-server/tools/fees.go
+++ b/lightning-mcp-server/tools/fees.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// FeeService proposes routing fee adjustments using only read-only RPCs.
+type FeeService struct {
+	LightningClient lnrpc.LightningClient
+}
+
+// feePageSize is the maximum number of forwarding events fetched per page.
+const feePageSize uint32 = 50000
+
+// NewFeeService creates a new FeeService.
+func NewFeeService(client lnrpc.LightningClient) *FeeService {
+	return &FeeService{LightningClient: client}
+}
+
+// ProposeFeesTool returns the MCP tool definition for propose_fees.
+func (s *FeeService) ProposeFeesTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "lnc_propose_fees",
+		Description: "Analyse routing history and channel balances to propose " +
+			"fee-rate adjustments per channel. Read-only: uses " +
+			"ForwardingHistory and ListChannels only.",
+		InputSchema: ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"days": map[string]any{
+					"type":        "number",
+					"description": "Lookback window in days for forwarding history (default 7, max 90)",
+					"minimum":     1,
+					"maximum":     90,
+				},
+				"min_fee_ppm": map[string]any{
+					"type":        "number",
+					"description": "Minimum proposed fee in parts-per-million (default 1)",
+					"minimum":     1,
+				},
+				"max_fee_ppm": map[string]any{
+					"type":        "number",
+					"description": "Maximum proposed fee in parts-per-million (default 5000)",
+					"minimum":     1,
+				},
+			},
+		},
+	}
+}
+
+// HandleProposeFees handles the propose_fees request.
+func (s *FeeService) HandleProposeFees(ctx context.Context,
+	request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+
+	if s.LightningClient == nil {
+		return newToolResultError(
+			"Not connected to Lightning node. Use lnc_connect first."), nil
+	}
+
+	args := requestArguments(request)
+
+	days, _ := args["days"].(float64)
+	if days <= 0 {
+		days = 7
+	}
+	if days > 90 {
+		days = 90
+	}
+
+	minFeePPM, _ := args["min_fee_ppm"].(float64)
+	if minFeePPM <= 0 {
+		minFeePPM = 1
+	}
+	maxFeePPM, _ := args["max_fee_ppm"].(float64)
+	if maxFeePPM <= 0 {
+		maxFeePPM = 5000
+	}
+
+	// Bug fix: reject inverted bounds before making any API calls.
+	if minFeePPM > maxFeePPM {
+		return newToolResultError(
+			"min_fee_ppm must not exceed max_fee_ppm"), nil
+	}
+
+	// Bug fix: convert fractional days to nanoseconds correctly so that
+	// values like 1.5 produce the right duration rather than truncating to
+	// the nearest integer day.
+	startTime := uint64(
+		time.Now().Add(
+			-time.Duration(days * 24 * float64(time.Hour)),
+		).Unix(),
+	)
+
+	// Bug fix: paginate ForwardingHistory so nodes with more than 50 000
+	// events in the window are not silently truncated.
+	type chanStats struct {
+		forwardsOut  int64
+		amtOutMsat   int64
+		feesEarnedMs int64
+	}
+	stats := make(map[uint64]*chanStats)
+	totalForwards := 0
+	var offset uint32
+	for {
+		batch, err := s.LightningClient.ForwardingHistory(
+			ctx, &lnrpc.ForwardingHistoryRequest{
+				StartTime:    startTime,
+				NumMaxEvents: feePageSize,
+				IndexOffset:  offset,
+			},
+		)
+		if err != nil {
+			return newToolResultError(
+				"Failed to fetch forwarding history: " + err.Error()), nil
+		}
+
+		totalForwards += len(batch.ForwardingEvents)
+		for _, ev := range batch.ForwardingEvents {
+			if _, ok := stats[ev.ChanIdOut]; !ok {
+				stats[ev.ChanIdOut] = &chanStats{}
+			}
+			s2 := stats[ev.ChanIdOut]
+			s2.forwardsOut++
+			s2.amtOutMsat += int64(ev.AmtOutMsat)
+			s2.feesEarnedMs += int64(ev.FeeMsat)
+		}
+
+		if uint32(len(batch.ForwardingEvents)) < feePageSize {
+			break
+		}
+		offset = batch.LastOffsetIndex
+	}
+
+	channels, err := s.LightningClient.ListChannels(
+		ctx, &lnrpc.ListChannelsRequest{},
+	)
+	if err != nil {
+		return newToolResultError(
+			"Failed to list channels: " + err.Error()), nil
+	}
+
+	proposals := make([]map[string]any, 0, len(channels.Channels))
+	for _, ch := range channels.Channels {
+		localRatio := float64(0)
+		if ch.Capacity > 0 {
+			localRatio = float64(ch.LocalBalance) / float64(ch.Capacity)
+		}
+
+		st := stats[ch.ChanId]
+		forwards := int64(0)
+		if st != nil {
+			forwards = st.forwardsOut
+		}
+
+		proposedPPM := proposeFee(localRatio, forwards, minFeePPM, maxFeePPM)
+
+		entry := map[string]any{
+			"chan_id":          strconv.FormatUint(ch.ChanId, 10),
+			"remote_pubkey":    ch.RemotePubkey,
+			"channel_point":    ch.ChannelPoint,
+			"capacity_sat":     ch.Capacity,
+			"local_balance":    ch.LocalBalance,
+			"remote_balance":   ch.RemoteBalance,
+			"local_ratio":      round2(localRatio),
+			"forwards_out":     forwards,
+			"proposed_fee_ppm": proposedPPM,
+			"reason":           feeReason(localRatio, forwards),
+		}
+		if st != nil {
+			entry["amt_routed_msat"] = st.amtOutMsat
+			entry["fees_earned_msat"] = st.feesEarnedMs
+		}
+		proposals = append(proposals, entry)
+	}
+
+	return newToolResultJSON(map[string]any{
+		"lookback_days":  days,
+		"total_forwards": totalForwards,
+		"proposals":      proposals,
+		"note":           "Proposals are suggestions only. Apply with UpdateChannelPolicy after review.",
+	}), nil
+}
+
+// proposeFee returns a fee in PPM based on local liquidity ratio and recent
+// forward count.
+//
+// Strategy:
+//   - Depleted channel (localRatio < 0.2): raise fees to slow outflow.
+//   - Saturated channel (localRatio > 0.8): lower fees to encourage outflow.
+//   - Idle channel (0 forwards in window): lower fees to attract routing.
+//   - Active balanced channel: scale proportionally between min and max.
+func proposeFee(localRatio float64, forwards int64, minPPM, maxPPM float64) int64 {
+	var ppm float64
+	switch {
+	case localRatio < 0.2:
+		// Bug fix: use range-relative formula (same pattern as all other
+		// branches) so the result respects minPPM and scales with the range.
+		ppm = minPPM + (maxPPM-minPPM)*0.90
+	case localRatio > 0.8:
+		// Over-full — lower fee to encourage outflow and rebalancing.
+		ppm = minPPM + (maxPPM-minPPM)*0.10
+	case forwards == 0:
+		// Idle channel — offer a discount to attract first routes.
+		ppm = minPPM + (maxPPM-minPPM)*0.15
+	default:
+		// Balanced and routing — linear scale: higher local ratio → lower fee.
+		ppm = minPPM + (maxPPM-minPPM)*(1-localRatio)
+	}
+
+	if ppm < minPPM {
+		ppm = minPPM
+	}
+	if ppm > maxPPM {
+		ppm = maxPPM
+	}
+	return int64(ppm)
+}
+
+func feeReason(localRatio float64, forwards int64) string {
+	switch {
+	case localRatio < 0.2:
+		return "depleted: raised fee to slow outflow"
+	case localRatio > 0.8:
+		return "saturated: lowered fee to encourage outflow"
+	case forwards == 0:
+		return "idle: discounted fee to attract routing"
+	default:
+		return "balanced and active: fee scaled by local liquidity ratio"
+	}
+}
+
+func round2(f float64) float64 {
+	return float64(int(f*100)) / 100
+}

--- a/lightning-mcp-server/tools/fees_test.go
+++ b/lightning-mcp-server/tools/fees_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// mockFeeClient satisfies lnrpc.LightningClient for the two methods
+// HandleProposeFees calls; all other methods panic if called.
+type mockFeeClient struct {
+	lnrpc.LightningClient
+	forwardingHistory func(context.Context, *lnrpc.ForwardingHistoryRequest, ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error)
+	listChannels      func(context.Context, *lnrpc.ListChannelsRequest, ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error)
+}
+
+func (m *mockFeeClient) ForwardingHistory(ctx context.Context, in *lnrpc.ForwardingHistoryRequest, opts ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+	return m.forwardingHistory(ctx, in, opts...)
+}
+
+func (m *mockFeeClient) ListChannels(ctx context.Context, in *lnrpc.ListChannelsRequest, opts ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+	return m.listChannels(ctx, in, opts...)
+}
+
+// makeFeeRequest builds a CallToolRequest with the given JSON arguments.
+func makeFeeRequest(args map[string]any) *mcp.CallToolRequest {
+	b, _ := json.Marshal(args)
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Arguments: json.RawMessage(b),
+		},
+	}
+}
+
+// emptyChannelsMock returns a listChannels stub that always returns zero
+// channels — useful when the test only cares about history behaviour.
+func emptyChannelsMock() func(context.Context, *lnrpc.ListChannelsRequest, ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+	return func(_ context.Context, _ *lnrpc.ListChannelsRequest, _ ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+		return &lnrpc.ListChannelsResponse{}, nil
+	}
+}
+
+// --- proposeFee unit tests (bug-4 regression + full branch coverage) ---
+
+func TestProposeFee_DepletedUsesRangeRelativeFormula(t *testing.T) {
+	// Bug 4: old code used maxPPM*0.80 (absolute), new code must use the
+	// range-relative pattern minPPM + (maxPPM-minPPM)*0.90.
+	min, max := 10.0, 1000.0
+	got := proposeFee(0.1, 5, min, max) // localRatio < 0.2 → depleted
+	want := int64(min + (max-min)*0.90) // 10 + 990*0.90 = 901
+	assert.Equal(t, want, got,
+		"depleted branch must use range-relative formula")
+
+	// Demonstrate that the old formula gives a different (wrong) answer when
+	// minPPM != 0.
+	oldFormula := int64(max * 0.80) // 800
+	assert.NotEqual(t, oldFormula, got,
+		"result must differ from the old absolute-percentage formula")
+}
+
+func TestProposeFee_AllBranches(t *testing.T) {
+	min, max := 10.0, 1000.0
+	range_ := max - min // 990
+
+	tests := []struct {
+		name       string
+		localRatio float64
+		forwards   int64
+		want       int64
+	}{
+		{
+			name:       "depleted",
+			localRatio: 0.1,
+			forwards:   3,
+			want:       int64(min + range_*0.90), // 901
+		},
+		{
+			name:       "saturated",
+			localRatio: 0.9,
+			forwards:   3,
+			want:       int64(min + range_*0.10), // 109
+		},
+		{
+			name:       "idle_balanced",
+			localRatio: 0.5,
+			forwards:   0,
+			want:       int64(min + range_*0.15), // 158
+		},
+		{
+			name:       "balanced_active_mid",
+			localRatio: 0.5,
+			forwards:   10,
+			want:       int64(min + range_*(1-0.5)), // 505
+		},
+		{
+			name:       "balanced_active_low_local",
+			localRatio: 0.3,
+			forwards:   10,
+			want:       int64(min + range_*(1-0.3)), // 703
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := proposeFee(tt.localRatio, tt.forwards, min, max)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestProposeFee_Clamping(t *testing.T) {
+	// When min == max every branch should return min (no division by zero).
+	got := proposeFee(0.1, 0, 100, 100)
+	assert.Equal(t, int64(100), got)
+
+	// Result is always within [min, max].
+	got = proposeFee(0.0, 0, 1, 5000)
+	assert.GreaterOrEqual(t, got, int64(1))
+	assert.LessOrEqual(t, got, int64(5000))
+}
+
+// --- FeeService tool-creation tests ---
+
+func TestFeeService_ProposeFeesTool(t *testing.T) {
+	svc := NewFeeService(nil)
+	tool := svc.ProposeFeesTool()
+
+	assert.Equal(t, "lnc_propose_fees", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+
+	schema := requireToolSchema(t, tool.InputSchema)
+	assert.Equal(t, "object", schema.Type)
+	assert.Contains(t, schema.Properties, "days")
+	assert.Contains(t, schema.Properties, "min_fee_ppm")
+	assert.Contains(t, schema.Properties, "max_fee_ppm")
+}
+
+// --- HandleProposeFees handler tests ---
+
+// TestHandleProposeFees_NoClient verifies the "not connected" guard.
+func TestHandleProposeFees_NoClient(t *testing.T) {
+	svc := NewFeeService(nil)
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(nil))
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+// TestHandleProposeFees_InvertedMinMax covers bug-2: inverted bounds must
+// be rejected before any API call is made.
+func TestHandleProposeFees_InvertedMinMax(t *testing.T) {
+	called := false
+	mock := &mockFeeClient{
+		forwardingHistory: func(_ context.Context, _ *lnrpc.ForwardingHistoryRequest, _ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+			called = true
+			return &lnrpc.ForwardingHistoryResponse{}, nil
+		},
+		listChannels: emptyChannelsMock(),
+	}
+
+	svc := NewFeeService(mock)
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(map[string]any{
+		"min_fee_ppm": 5000,
+		"max_fee_ppm": 1,
+	}))
+	require.NoError(t, err)
+	assert.True(t, result.IsError, "inverted bounds must produce an error result")
+	assert.False(t, called, "no API call must be made when bounds are inverted")
+}
+
+// TestHandleProposeFees_FractionalDays covers bug-1: a fractional day value
+// must produce a startTime that is proportionally in the past, not zero.
+func TestHandleProposeFees_FractionalDays(t *testing.T) {
+	var capturedStart uint64
+	mock := &mockFeeClient{
+		forwardingHistory: func(_ context.Context, in *lnrpc.ForwardingHistoryRequest, _ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+			capturedStart = in.StartTime
+			return &lnrpc.ForwardingHistoryResponse{}, nil
+		},
+		listChannels: emptyChannelsMock(),
+	}
+
+	before := time.Now()
+	svc := NewFeeService(mock)
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(map[string]any{
+		"days": 0.5,
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	// 0.5 days = 12 hours ago.  Allow ±5 s for test execution.
+	expected := uint64(before.Add(-12 * time.Hour).Unix())
+	delta := int64(capturedStart) - int64(expected)
+	if delta < 0 {
+		delta = -delta
+	}
+	assert.LessOrEqual(t, delta, int64(5),
+		"startTime for 0.5 days must be ~12 hours ago, not zero")
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+	assert.Equal(t, 0.5, resp["lookback_days"])
+}
+
+// TestHandleProposeFees_Pagination covers bug-3: history spanning more than
+// 50 000 events must be fully fetched via multiple pages.
+func TestHandleProposeFees_Pagination(t *testing.T) {
+	const firstPageSize = int(feePageSize) // 50 000 events on first page
+	callCount := 0
+
+	mock := &mockFeeClient{
+		forwardingHistory: func(_ context.Context, in *lnrpc.ForwardingHistoryRequest, _ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+			callCount++
+			if callCount == 1 {
+				require.Equal(t, uint32(0), in.IndexOffset)
+				// First page: return a full page of events.
+				events := make([]*lnrpc.ForwardingEvent, firstPageSize)
+				for i := range events {
+					events[i] = &lnrpc.ForwardingEvent{ChanIdOut: 1}
+				}
+				return &lnrpc.ForwardingHistoryResponse{
+					ForwardingEvents: events,
+					LastOffsetIndex:  uint32(firstPageSize),
+				}, nil
+			}
+
+			require.Equal(t, uint32(firstPageSize), in.IndexOffset)
+			// Second page: return one more event to complete pagination.
+			return &lnrpc.ForwardingHistoryResponse{
+				ForwardingEvents: []*lnrpc.ForwardingEvent{
+					{ChanIdOut: 1},
+				},
+				LastOffsetIndex: uint32(firstPageSize),
+			}, nil
+		},
+		listChannels: emptyChannelsMock(),
+	}
+
+	svc := NewFeeService(mock)
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(nil))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	// Decode response and verify total_forwards includes both pages.
+	text := result.Content[0].(*mcp.TextContent).Text
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+	totalForwards, ok := resp["total_forwards"].(float64)
+	require.True(t, ok)
+	assert.Equal(t, float64(firstPageSize+1), totalForwards,
+		"all events across pages must be counted")
+	assert.Equal(t, 2, callCount, "must make exactly two ForwardingHistory calls")
+}

--- a/lightning-mcp-server/tools/fees_test.go
+++ b/lightning-mcp-server/tools/fees_test.go
@@ -22,6 +22,7 @@ type mockFeeClient struct {
 	lnrpc.LightningClient
 	forwardingHistory func(context.Context, *lnrpc.ForwardingHistoryRequest, ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error)
 	listChannels      func(context.Context, *lnrpc.ListChannelsRequest, ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error)
+	feeReport         func(context.Context, *lnrpc.FeeReportRequest, ...grpc.CallOption) (*lnrpc.FeeReportResponse, error)
 }
 
 func (m *mockFeeClient) ForwardingHistory(ctx context.Context, in *lnrpc.ForwardingHistoryRequest, opts ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
@@ -30,6 +31,13 @@ func (m *mockFeeClient) ForwardingHistory(ctx context.Context, in *lnrpc.Forward
 
 func (m *mockFeeClient) ListChannels(ctx context.Context, in *lnrpc.ListChannelsRequest, opts ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
 	return m.listChannels(ctx, in, opts...)
+}
+
+func (m *mockFeeClient) FeeReport(ctx context.Context, in *lnrpc.FeeReportRequest, opts ...grpc.CallOption) (*lnrpc.FeeReportResponse, error) {
+	if m.feeReport == nil {
+		return &lnrpc.FeeReportResponse{}, nil
+	}
+	return m.feeReport(ctx, in, opts...)
 }
 
 // makeFeeRequest builds a CallToolRequest with the given JSON arguments.
@@ -143,6 +151,11 @@ func TestFeeService_ProposeFeesTool(t *testing.T) {
 	assert.Contains(t, schema.Properties, "days")
 	assert.Contains(t, schema.Properties, "min_fee_ppm")
 	assert.Contains(t, schema.Properties, "max_fee_ppm")
+
+	days, ok := schema.Properties["days"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 0, days["exclusiveMinimum"])
+	assert.NotContains(t, days, "minimum")
 }
 
 // --- HandleProposeFees handler tests ---
@@ -210,6 +223,51 @@ func TestHandleProposeFees_FractionalDays(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal([]byte(text), &resp))
 	assert.Equal(t, 0.5, resp["lookback_days"])
+}
+
+func TestHandleProposeFees_IncludesCurrentFees(t *testing.T) {
+	mock := &mockFeeClient{
+		forwardingHistory: func(_ context.Context, _ *lnrpc.ForwardingHistoryRequest, _ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+			return &lnrpc.ForwardingHistoryResponse{}, nil
+		},
+		listChannels: func(_ context.Context, _ *lnrpc.ListChannelsRequest, _ ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+			return &lnrpc.ListChannelsResponse{
+				Channels: []*lnrpc.Channel{{
+					ChanId: 1, Capacity: 1_000_000,
+					LocalBalance: 500_000, RemoteBalance: 500_000,
+				}},
+			}, nil
+		},
+		feeReport: func(_ context.Context, _ *lnrpc.FeeReportRequest, _ ...grpc.CallOption) (*lnrpc.FeeReportResponse, error) {
+			return &lnrpc.FeeReportResponse{
+				ChannelFees: []*lnrpc.ChannelFeeReport{{
+					ChanId:       1,
+					BaseFeeMsat:  1_000,
+					FeePerMil:    250,
+					ChannelPoint: "tx:0",
+				}},
+			}, nil
+		},
+	}
+
+	svc := NewFeeService(mock)
+	result, err := svc.HandleProposeFees(context.Background(), makeFeeRequest(nil))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+	proposals := resp["proposals"].([]any)
+	require.Len(t, proposals, 1)
+	proposal := proposals[0].(map[string]any)
+
+	assert.Equal(t, float64(250), proposal["current_fee_ppm"])
+	assert.Equal(t, float64(1_000), proposal["current_base_fee_msat"])
+	assert.Equal(t,
+		proposal["proposed_fee_ppm"].(float64)-proposal["current_fee_ppm"].(float64),
+		proposal["fee_delta_ppm"],
+	)
 }
 
 // TestHandleProposeFees_Pagination covers bug-3: history spanning more than

--- a/lightning-mcp-server/tools/health.go
+++ b/lightning-mcp-server/tools/health.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// HealthService aggregates node health data into prioritized alerts.
+type HealthService struct {
+	LightningClient lnrpc.LightningClient
+}
+
+// NewHealthService creates a new health service.
+func NewHealthService(client lnrpc.LightningClient) *HealthService {
+	return &HealthService{
+		LightningClient: client,
+	}
+}
+
+// NodeHealthTool returns the MCP tool definition for node health alerts.
+func (s *HealthService) NodeHealthTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "lnc_node_health",
+		Description: "Aggregate node health alerts: force-closing channels, " +
+			"peer flap counts, and sync status into a prioritized list",
+		InputSchema: ToolInputSchema{
+			Type:       "object",
+			Properties: map[string]any{},
+		},
+	}
+}
+
+// HandleNodeHealth handles the node health request.
+func (s *HealthService) HandleNodeHealth(ctx context.Context,
+	request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+
+	if s.LightningClient == nil {
+		return newToolResultError(
+			"Not connected to Lightning node. " +
+				"Use lnc_connect first."), nil
+	}
+
+	alerts := make([]map[string]any, 0)
+
+	// --- sync status (from GetInfo) ---
+	info, err := s.LightningClient.GetInfo(ctx, &lnrpc.GetInfoRequest{})
+	if err != nil {
+		return newToolResultError(
+			"Failed to get node info: " + err.Error()), nil
+	}
+
+	if !info.SyncedToChain {
+		alerts = append(alerts, map[string]any{
+			"severity": "critical",
+			"category": "sync",
+			"message":  "Node is NOT synced to chain",
+		})
+	}
+	if !info.SyncedToGraph {
+		alerts = append(alerts, map[string]any{
+			"severity": "warning",
+			"category": "sync",
+			"message":  "Node is NOT synced to graph",
+		})
+	}
+
+	// --- force-closing / waiting-close channels (from PendingChannels) ---
+	pending, err := s.LightningClient.PendingChannels(
+		ctx, &lnrpc.PendingChannelsRequest{},
+	)
+	if err != nil {
+		return newToolResultError(
+			"Failed to get pending channels: " + err.Error()), nil
+	}
+
+	for _, ch := range pending.PendingForceClosingChannels {
+		alerts = append(alerts, map[string]any{
+			"severity":            "critical",
+			"category":            "channel",
+			"message":             "Force-closing channel detected",
+			"channel_point":       ch.Channel.ChannelPoint,
+			"remote_node_pub":     ch.Channel.RemoteNodePub,
+			"limbo_balance_sat":   ch.LimboBalance,
+			"blocks_til_maturity": ch.BlocksTilMaturity,
+			"closing_txid":        ch.ClosingTxid,
+		})
+	}
+
+	for _, ch := range pending.WaitingCloseChannels {
+		alerts = append(alerts, map[string]any{
+			"severity":          "warning",
+			"category":          "channel",
+			"message":           "Channel waiting to close",
+			"channel_point":     ch.Channel.ChannelPoint,
+			"remote_node_pub":   ch.Channel.RemoteNodePub,
+			"limbo_balance_sat": ch.LimboBalance,
+		})
+	}
+
+	// --- peer flap counts (from ListPeers) ---
+	const flapThreshold = int32(10)
+	peers, err := s.LightningClient.ListPeers(
+		ctx, &lnrpc.ListPeersRequest{},
+	)
+	if err != nil {
+		return newToolResultError(
+			"Failed to list peers: " + err.Error()), nil
+	}
+
+	for _, peer := range peers.Peers {
+		if peer.FlapCount >= flapThreshold {
+			alerts = append(alerts, map[string]any{
+				"severity":   "warning",
+				"category":   "peer",
+				"message":    fmt.Sprintf("Peer has high flap count (%d)", peer.FlapCount),
+				"pub_key":    peer.PubKey,
+				"address":    peer.Address,
+				"flap_count": peer.FlapCount,
+			})
+		}
+	}
+
+	sort.SliceStable(alerts, func(i, j int) bool {
+		return healthSeverityRank(alerts[i]["severity"]) <
+			healthSeverityRank(alerts[j]["severity"])
+	})
+
+	// Summarize counts per severity.
+	critical, warning := 0, 0
+	for _, a := range alerts {
+		switch a["severity"] {
+		case "critical":
+			critical++
+		case "warning":
+			warning++
+		}
+	}
+
+	overall := "healthy"
+	if critical > 0 {
+		overall = "critical"
+	} else if warning > 0 {
+		overall = "degraded"
+	}
+
+	return newToolResultJSON(map[string]any{
+		"overall_status":  overall,
+		"alert_count":     len(alerts),
+		"critical_count":  critical,
+		"warning_count":   warning,
+		"alerts":          alerts,
+		"node_id":         info.IdentityPubkey,
+		"alias":           info.Alias,
+		"synced_to_chain": info.SyncedToChain,
+		"synced_to_graph": info.SyncedToGraph,
+		"block_height":    info.BlockHeight,
+	}), nil
+}
+
+func healthSeverityRank(severity any) int {
+	switch severity {
+	case "critical":
+		return 0
+	case "warning":
+		return 1
+	default:
+		return 2
+	}
+}

--- a/lightning-mcp-server/tools/health_test.go
+++ b/lightning-mcp-server/tools/health_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type mockHealthClient struct {
+	lnrpc.LightningClient
+	info    *lnrpc.GetInfoResponse
+	pending *lnrpc.PendingChannelsResponse
+	peers   *lnrpc.ListPeersResponse
+}
+
+func (m *mockHealthClient) GetInfo(context.Context, *lnrpc.GetInfoRequest,
+	...grpc.CallOption) (*lnrpc.GetInfoResponse, error) {
+
+	return m.info, nil
+}
+
+func (m *mockHealthClient) PendingChannels(context.Context,
+	*lnrpc.PendingChannelsRequest,
+	...grpc.CallOption) (*lnrpc.PendingChannelsResponse, error) {
+
+	return m.pending, nil
+}
+
+func (m *mockHealthClient) ListPeers(context.Context, *lnrpc.ListPeersRequest,
+	...grpc.CallOption) (*lnrpc.ListPeersResponse, error) {
+
+	return m.peers, nil
+}
+
+func decodeHealthResult(t *testing.T,
+	result *mcp.CallToolResult) map[string]any {
+
+	t.Helper()
+	require.NotEmpty(t, result.Content)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &out))
+	return out
+}
+
+func TestHealthService_HealthyAlertsAreEmptyArray(t *testing.T) {
+	svc := NewHealthService(&mockHealthClient{
+		info: &lnrpc.GetInfoResponse{
+			IdentityPubkey: "node",
+			Alias:          "test-node",
+			SyncedToChain:  true,
+			SyncedToGraph:  true,
+			BlockHeight:    42,
+		},
+		pending: &lnrpc.PendingChannelsResponse{},
+		peers:   &lnrpc.ListPeersResponse{},
+	})
+
+	result, err := svc.HandleNodeHealth(
+		context.Background(), &mcp.CallToolRequest{},
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := decodeHealthResult(t, result)
+	assert.Equal(t, "healthy", out["overall_status"])
+	assert.Equal(t, float64(0), out["alert_count"])
+	alerts, ok := out["alerts"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, alerts)
+}
+
+func TestHealthService_CriticalAlertsArePrioritized(t *testing.T) {
+	svc := NewHealthService(&mockHealthClient{
+		info: &lnrpc.GetInfoResponse{
+			IdentityPubkey: "node",
+			Alias:          "test-node",
+			SyncedToChain:  true,
+			SyncedToGraph:  false,
+			BlockHeight:    42,
+		},
+		pending: &lnrpc.PendingChannelsResponse{
+			PendingForceClosingChannels: []*lnrpc.PendingChannelsResponse_ForceClosedChannel{
+				{
+					Channel: &lnrpc.PendingChannelsResponse_PendingChannel{
+						ChannelPoint:  "force:0",
+						RemoteNodePub: "remote-force",
+					},
+					LimboBalance:      10_000,
+					BlocksTilMaturity: 3,
+					ClosingTxid:       "close-tx",
+				},
+			},
+		},
+		peers: &lnrpc.ListPeersResponse{
+			Peers: []*lnrpc.Peer{{
+				PubKey:    "peer",
+				Address:   "127.0.0.1:9735",
+				FlapCount: 10,
+			}},
+		},
+	})
+
+	result, err := svc.HandleNodeHealth(
+		context.Background(), &mcp.CallToolRequest{},
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := decodeHealthResult(t, result)
+	assert.Equal(t, "critical", out["overall_status"])
+	assert.Equal(t, float64(1), out["critical_count"])
+	assert.Equal(t, float64(2), out["warning_count"])
+
+	alerts := out["alerts"].([]any)
+	require.Len(t, alerts, 3)
+	assert.Equal(t, "critical",
+		alerts[0].(map[string]any)["severity"])
+	assert.Equal(t, "warning",
+		alerts[1].(map[string]any)["severity"])
+	assert.Equal(t, "warning",
+		alerts[2].(map[string]any)["severity"])
+}

--- a/lightning-mcp-server/tools/rebalance.go
+++ b/lightning-mcp-server/tools/rebalance.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/grpc"
+)
+
+const (
+	defaultRebalanceThreshold     = 0.65
+	defaultMaxRebalanceCandidates = 10
+	defaultRebalanceMaxFeePPM     = 500
+	minRebalanceAmountSat         = 20_000
+	fwdHistoryLookbackDays        = 30
+	rebalanceHistoryPageSize      = 50_000
+)
+
+// rebalanceClient is the narrow read-only interface used by RebalanceService.
+// The method signatures match lnrpc.LightningClient so any gRPC-generated
+// client satisfies this interface without wrapping.
+type rebalanceClient interface {
+	ListChannels(context.Context, *lnrpc.ListChannelsRequest,
+		...grpc.CallOption) (*lnrpc.ListChannelsResponse, error)
+	ForwardingHistory(context.Context, *lnrpc.ForwardingHistoryRequest,
+		...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error)
+}
+
+// chanSnapshot holds per-channel data for rebalance analysis.
+type chanSnapshot struct {
+	chanID    uint64
+	chanIDStr string
+	remotePub string
+	capacity  int64
+	local     int64
+	remote    int64
+	ratio     float64
+	// fwdNetSat is net outbound sats over the lookback window
+	// (positive means the channel sent more than it received).
+	fwdNetSat int64
+}
+
+// RebalanceService detects imbalanced channels and proposes rebalancing.
+type RebalanceService struct {
+	LightningClient rebalanceClient
+}
+
+// NewRebalanceService creates a new rebalance service.
+func NewRebalanceService(client rebalanceClient) *RebalanceService {
+	return &RebalanceService{LightningClient: client}
+}
+
+// ProposeRebalanceTool returns the MCP tool definition for lnc_propose_rebalance.
+func (s *RebalanceService) ProposeRebalanceTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name: "lnc_propose_rebalance",
+		Description: "Detect imbalanced Lightning channels and propose circular " +
+			"rebalance candidates. Read-only — returns proposals only, does not " +
+			"move funds.",
+		InputSchema: ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"imbalance_threshold": map[string]any{
+					"type": "number",
+					"description": "Local-balance ratio above which a channel is " +
+						"over-local (mirrored for over-remote). " +
+						"Range 0.5–0.95; default 0.65.",
+					"default": 0.65,
+				},
+				"max_candidates": map[string]any{
+					"type":        "integer",
+					"description": "Maximum candidates to return (default 10).",
+					"default":     10,
+				},
+				"max_fee_ppm": map[string]any{
+					"type": "integer",
+					"description": "Suggested maximum rebalance fee in " +
+						"parts-per-million (default 500).",
+					"default": 500,
+				},
+				"include_forwarding_demand": map[string]any{
+					"type": "boolean",
+					"description": "Enrich candidates with 30-day forwarding " +
+						"volume to highlight demand-driven urgency (default true).",
+					"default": true,
+				},
+			},
+		},
+	}
+}
+
+// HandleProposeRebalance handles the lnc_propose_rebalance tool call.
+func (s *RebalanceService) HandleProposeRebalance(ctx context.Context,
+	request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+
+	if s.LightningClient == nil {
+		return newToolResultError(
+			"Not connected to Lightning node. Use lnc_connect first."), nil
+	}
+
+	args := requestArguments(request)
+
+	threshold := defaultRebalanceThreshold
+	if v, ok := args["imbalance_threshold"].(float64); ok && v > 0.5 && v < 1.0 {
+		threshold = v
+	}
+	maxCandidates := defaultMaxRebalanceCandidates
+	if v, ok := args["max_candidates"].(float64); ok && int(v) > 0 {
+		maxCandidates = int(v)
+	}
+	maxFeePPM := int64(defaultRebalanceMaxFeePPM)
+	if v, ok := args["max_fee_ppm"].(float64); ok && v > 0 {
+		maxFeePPM = int64(v)
+	}
+	includeFwd := true
+	if v, ok := args["include_forwarding_demand"].(bool); ok {
+		includeFwd = v
+	}
+
+	chanResp, err := s.LightningClient.ListChannels(
+		ctx, &lnrpc.ListChannelsRequest{ActiveOnly: true},
+	)
+	if err != nil {
+		return newToolResultError(
+			"Failed to list channels: " + err.Error()), nil
+	}
+
+	fwdNet := map[uint64]int64{}
+	if includeFwd {
+		fwdNet = s.forwardingNetFlow(ctx)
+	}
+
+	var overLocal, overRemote []chanSnapshot
+	for _, ch := range chanResp.Channels {
+		if ch.Capacity == 0 {
+			continue
+		}
+		ratio := float64(ch.LocalBalance) / float64(ch.Capacity)
+		snap := chanSnapshot{
+			chanID:    ch.ChanId,
+			chanIDStr: strconv.FormatUint(ch.ChanId, 10),
+			remotePub: ch.RemotePubkey,
+			capacity:  ch.Capacity,
+			local:     ch.LocalBalance,
+			remote:    ch.RemoteBalance,
+			ratio:     ratio,
+			fwdNetSat: fwdNet[ch.ChanId],
+		}
+		switch {
+		case ratio > threshold:
+			overLocal = append(overLocal, snap)
+		case ratio < (1.0 - threshold):
+			overRemote = append(overRemote, snap)
+		}
+	}
+
+	sortSnapshots(overLocal, true)   // descending: most over-local first
+	sortSnapshots(overRemote, false) // ascending: most over-remote first
+
+	type rebalanceCandidate struct {
+		OutChan   string `json:"out_chan"`
+		InChan    string `json:"in_chan"`
+		AmountSat int64  `json:"amount_sat"`
+		MaxFeePPM int64  `json:"max_fee_ppm"`
+		Reason    string `json:"reason"`
+	}
+
+	candidates := make([]rebalanceCandidate, 0)
+outer:
+	for _, ol := range overLocal {
+		for _, ir := range overRemote {
+			if len(candidates) >= maxCandidates {
+				break outer
+			}
+			excessLocal := ol.local - ol.capacity/2
+			deficitLocal := ir.capacity/2 - ir.local
+			amount := min64(excessLocal, deficitLocal)
+			if amount < minRebalanceAmountSat {
+				continue
+			}
+
+			reason := fmt.Sprintf(
+				"out_chan %.0f%% local (excess %d sat); "+
+					"in_chan %.0f%% local (deficit %d sat)",
+				ol.ratio*100, excessLocal, ir.ratio*100, deficitLocal,
+			)
+			if includeFwd {
+				if ol.fwdNetSat < 0 {
+					reason += fmt.Sprintf(
+						"; out_chan has net inbound pressure (%d sat net), "+
+							"rebalance is urgent",
+						ol.fwdNetSat,
+					)
+				}
+				if ir.fwdNetSat > 0 {
+					reason += fmt.Sprintf(
+						"; in_chan has net outbound pressure (+%d sat net), "+
+							"rebalance is urgent",
+						ir.fwdNetSat,
+					)
+				}
+			}
+
+			candidates = append(candidates, rebalanceCandidate{
+				OutChan:   ol.chanIDStr,
+				InChan:    ir.chanIDStr,
+				AmountSat: amount,
+				MaxFeePPM: maxFeePPM,
+				Reason:    reason,
+			})
+		}
+	}
+
+	return newToolResultJSON(map[string]any{
+		"candidates": candidates,
+		"analysis": map[string]any{
+			"over_local_channels":   snapsToMaps(overLocal, includeFwd),
+			"over_remote_channels":  snapsToMaps(overRemote, includeFwd),
+			"threshold":             threshold,
+			"total_active_channels": len(chanResp.Channels),
+		},
+	}), nil
+}
+
+// forwardingNetFlow fetches 30-day forwarding history and returns a per-channel
+// map of net outbound satoshis. Returns an empty map on error so callers
+// degrade gracefully.
+func (s *RebalanceService) forwardingNetFlow(
+	ctx context.Context) map[uint64]int64 {
+
+	now := time.Now()
+	startTime := uint64(
+		now.Add(-fwdHistoryLookbackDays * 24 * time.Hour).Unix(),
+	)
+	endTime := uint64(now.Unix())
+
+	net := make(map[uint64]int64)
+	var offset uint32
+	for {
+		resp, err := s.LightningClient.ForwardingHistory(ctx,
+			&lnrpc.ForwardingHistoryRequest{
+				StartTime:    startTime,
+				EndTime:      endTime,
+				NumMaxEvents: rebalanceHistoryPageSize,
+				IndexOffset:  offset,
+			},
+		)
+		if err != nil {
+			return map[uint64]int64{}
+		}
+		for _, ev := range resp.ForwardingEvents {
+			net[ev.ChanIdOut] += int64(ev.AmtOut)
+			net[ev.ChanIdIn] -= int64(ev.AmtIn)
+		}
+
+		if uint32(len(resp.ForwardingEvents)) < rebalanceHistoryPageSize {
+			break
+		}
+		nextOffset := resp.LastOffsetIndex
+		if nextOffset == offset {
+			break
+		}
+		offset = nextOffset
+	}
+	return net
+}
+
+// sortSnapshots sorts channel snapshots by ratio, descending if desc=true.
+func sortSnapshots(snaps []chanSnapshot, desc bool) {
+	for i := 1; i < len(snaps); i++ {
+		for j := i; j > 0; j-- {
+			swap := desc && snaps[j].ratio > snaps[j-1].ratio ||
+				!desc && snaps[j].ratio < snaps[j-1].ratio
+			if !swap {
+				break
+			}
+			snaps[j], snaps[j-1] = snaps[j-1], snaps[j]
+		}
+	}
+}
+
+// snapsToMaps converts channel snapshots to JSON-serialisable maps.
+func snapsToMaps(snaps []chanSnapshot, includeFwd bool) []map[string]any {
+	out := make([]map[string]any, len(snaps))
+	for i, sn := range snaps {
+		m := map[string]any{
+			"chan_id":        sn.chanIDStr,
+			"remote_pubkey":  sn.remotePub,
+			"capacity":       sn.capacity,
+			"local_balance":  sn.local,
+			"remote_balance": sn.remote,
+			"local_ratio":    fmt.Sprintf("%.2f", sn.ratio),
+		}
+		if includeFwd {
+			m["fwd_net_flow_sat"] = sn.fwdNetSat
+		}
+		out[i] = m
+	}
+	return out
+}
+
+// min64 returns the smaller of two int64 values.
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/lightning-mcp-server/tools/rebalance_test.go
+++ b/lightning-mcp-server/tools/rebalance_test.go
@@ -1,0 +1,407 @@
+// Copyright (c) 2025 Lightning Labs
+// Distributed under the MIT license. See LICENSE for details.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// stubRebalanceClient is a minimal test double for the rebalanceClient
+// interface.
+type stubRebalanceClient struct {
+	channels     []*lnrpc.Channel
+	fwdErr       bool
+	fwdEvents    []*lnrpc.ForwardingEvent
+	fwdResponses []*lnrpc.ForwardingHistoryResponse
+	fwdRequests  []*lnrpc.ForwardingHistoryRequest
+}
+
+func (s *stubRebalanceClient) ListChannels(_ context.Context,
+	_ *lnrpc.ListChannelsRequest,
+	_ ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+	return &lnrpc.ListChannelsResponse{Channels: s.channels}, nil
+}
+
+func (s *stubRebalanceClient) ForwardingHistory(_ context.Context,
+	req *lnrpc.ForwardingHistoryRequest,
+	_ ...grpc.CallOption) (*lnrpc.ForwardingHistoryResponse, error) {
+	if s.fwdErr {
+		return nil, errors.New("unavailable")
+	}
+	s.fwdRequests = append(s.fwdRequests, &lnrpc.ForwardingHistoryRequest{
+		StartTime:    req.StartTime,
+		EndTime:      req.EndTime,
+		NumMaxEvents: req.NumMaxEvents,
+		IndexOffset:  req.IndexOffset,
+	})
+	if len(s.fwdResponses) > 0 {
+		idx := len(s.fwdRequests) - 1
+		if idx < len(s.fwdResponses) {
+			return s.fwdResponses[idx], nil
+		}
+		return &lnrpc.ForwardingHistoryResponse{}, nil
+	}
+	return &lnrpc.ForwardingHistoryResponse{
+		ForwardingEvents: s.fwdEvents,
+	}, nil
+}
+
+// makeRebalanceReq builds a CallToolRequest with the given args.
+func makeRebalanceReq(t *testing.T, args map[string]any) *mcp.CallToolRequest {
+	t.Helper()
+	b, err := json.Marshal(args)
+	require.NoError(t, err)
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Arguments: b},
+	}
+}
+
+// resultText extracts the text payload from the first content item.
+func resultText(t *testing.T, r *mcp.CallToolResult) string {
+	t.Helper()
+	require.NotEmpty(t, r.Content)
+	tc, ok := r.Content[0].(*mcp.TextContent)
+	require.True(t, ok, "expected *mcp.TextContent")
+	return tc.Text
+}
+
+// unmarshalResult unmarshals the tool result into a map.
+func unmarshalResult(t *testing.T, r *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, r)), &out))
+	return out
+}
+
+func TestRebalanceService_ToolDefinition(t *testing.T) {
+	svc := NewRebalanceService(nil)
+	tool := svc.ProposeRebalanceTool()
+
+	assert.Equal(t, "lnc_propose_rebalance", tool.Name)
+	assert.Contains(t, tool.Description, "Read-only")
+	assert.Contains(t, tool.Description, "rebalance")
+
+	schema := requireToolSchema(t, tool.InputSchema)
+	assert.Equal(t, "object", schema.Type)
+
+	for _, prop := range []string{
+		"imbalance_threshold",
+		"max_candidates",
+		"max_fee_ppm",
+		"include_forwarding_demand",
+	} {
+		assert.Contains(t, schema.Properties, prop,
+			"expected property %q in schema", prop)
+	}
+}
+
+func TestRebalanceService_NilClient(t *testing.T) {
+	svc := NewRebalanceService(nil)
+	result, err := svc.HandleProposeRebalance(
+		context.Background(), &mcp.CallToolRequest{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestRebalanceService_BalancedChannels(t *testing.T) {
+	// All channels at 50 % — no candidates expected.
+	stub := &stubRebalanceClient{
+		channels: []*lnrpc.Channel{
+			{
+				ChanId: 1, Capacity: 1_000_000,
+				LocalBalance: 500_000, RemoteBalance: 500_000,
+				RemotePubkey: "aaa",
+			},
+			{
+				ChanId: 2, Capacity: 2_000_000,
+				LocalBalance: 1_000_000, RemoteBalance: 1_000_000,
+				RemotePubkey: "bbb",
+			},
+		},
+	}
+	svc := NewRebalanceService(stub)
+
+	result, err := svc.HandleProposeRebalance(
+		context.Background(),
+		makeRebalanceReq(t, map[string]any{"include_forwarding_demand": false}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := unmarshalResult(t, result)
+	candidates, ok := out["candidates"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, candidates, "no candidates for balanced channels")
+}
+
+func TestRebalanceService_ImbalancedChannels(t *testing.T) {
+	// ch1 is 80 % local (over-local), ch2 is 20 % local (over-remote).
+	stub := &stubRebalanceClient{
+		channels: []*lnrpc.Channel{
+			{
+				ChanId: 1, Capacity: 1_000_000,
+				LocalBalance: 800_000, RemoteBalance: 200_000,
+				RemotePubkey: "aaa",
+			},
+			{
+				ChanId: 2, Capacity: 1_000_000,
+				LocalBalance: 200_000, RemoteBalance: 800_000,
+				RemotePubkey: "bbb",
+			},
+		},
+	}
+	svc := NewRebalanceService(stub)
+
+	result, err := svc.HandleProposeRebalance(
+		context.Background(),
+		makeRebalanceReq(t, map[string]any{"include_forwarding_demand": false}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := unmarshalResult(t, result)
+	candidates, ok := out["candidates"].([]any)
+	require.True(t, ok)
+	require.Len(t, candidates, 1, "expected one rebalance candidate")
+
+	c := candidates[0].(map[string]any)
+	assert.Equal(t, "1", c["out_chan"])
+	assert.Equal(t, "2", c["in_chan"])
+	// Both channels have 300 000 sat excess/deficit from the 500 000-sat midpoint.
+	amount := int64(c["amount_sat"].(float64))
+	assert.Equal(t, int64(300_000), amount)
+	assert.NotEmpty(t, c["reason"])
+	assert.NotEmpty(t, c["max_fee_ppm"])
+}
+
+func TestRebalanceService_MinAmountFiltered(t *testing.T) {
+	// Channels are imbalanced but the rebalance amount is below the minimum.
+	// Capacity 80 000 sat, 70 % local → excess = 56 000 − 40 000 = 16 000 sat
+	// which is below minRebalanceAmountSat (20 000), so no candidate is proposed.
+	stub := &stubRebalanceClient{
+		channels: []*lnrpc.Channel{
+			{
+				ChanId: 1, Capacity: 80_000,
+				LocalBalance: 56_000, RemoteBalance: 24_000,
+				RemotePubkey: "aaa",
+			},
+			{
+				ChanId: 2, Capacity: 80_000,
+				LocalBalance: 24_000, RemoteBalance: 56_000,
+				RemotePubkey: "bbb",
+			},
+		},
+	}
+	svc := NewRebalanceService(stub)
+
+	result, err := svc.HandleProposeRebalance(
+		context.Background(),
+		makeRebalanceReq(t, map[string]any{"include_forwarding_demand": false}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := unmarshalResult(t, result)
+	candidates := out["candidates"].([]any)
+	assert.Empty(t, candidates, "amount below minimum should produce no candidates")
+}
+
+func TestRebalanceService_ForwardingDemandEnrichment(t *testing.T) {
+	// ch1 receives more than it forwards (net inbound) → urgent to drain.
+	stub := &stubRebalanceClient{
+		channels: []*lnrpc.Channel{
+			{
+				ChanId: 1, Capacity: 2_000_000,
+				LocalBalance: 1_600_000, RemoteBalance: 400_000,
+				RemotePubkey: "aaa",
+			},
+			{
+				ChanId: 2, Capacity: 2_000_000,
+				LocalBalance: 400_000, RemoteBalance: 1_600_000,
+				RemotePubkey: "bbb",
+			},
+		},
+		fwdEvents: []*lnrpc.ForwardingEvent{
+			// More in than out on channel 1 → negative net flow.
+			{ChanIdIn: 1, AmtIn: 500_000, ChanIdOut: 99, AmtOut: 0},
+		},
+	}
+	svc := NewRebalanceService(stub)
+
+	result, err := svc.HandleProposeRebalance(
+		context.Background(),
+		makeRebalanceReq(t, map[string]any{"include_forwarding_demand": true}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := unmarshalResult(t, result)
+	candidates := out["candidates"].([]any)
+	require.Len(t, candidates, 1)
+	reason := candidates[0].(map[string]any)["reason"].(string)
+	assert.Contains(t, reason, "urgent", "demand pressure should mark candidate as urgent")
+}
+
+func TestRebalanceService_ForwardingDemandPagination(t *testing.T) {
+	firstPage := make([]*lnrpc.ForwardingEvent, rebalanceHistoryPageSize)
+	for i := range firstPage {
+		firstPage[i] = &lnrpc.ForwardingEvent{
+			ChanIdIn: 1,
+			AmtIn:    1,
+		}
+	}
+	stub := &stubRebalanceClient{
+		channels: []*lnrpc.Channel{
+			{
+				ChanId: 1, Capacity: 2_000_000,
+				LocalBalance: 1_600_000, RemoteBalance: 400_000,
+				RemotePubkey: "aaa",
+			},
+			{
+				ChanId: 2, Capacity: 2_000_000,
+				LocalBalance: 400_000, RemoteBalance: 1_600_000,
+				RemotePubkey: "bbb",
+			},
+		},
+		fwdResponses: []*lnrpc.ForwardingHistoryResponse{
+			{
+				ForwardingEvents: firstPage,
+				LastOffsetIndex:  rebalanceHistoryPageSize,
+			},
+			{
+				ForwardingEvents: []*lnrpc.ForwardingEvent{
+					{
+						ChanIdIn: 1,
+						AmtIn:    1,
+					},
+				},
+				LastOffsetIndex: rebalanceHistoryPageSize,
+			},
+		},
+	}
+	svc := NewRebalanceService(stub)
+
+	result, err := svc.HandleProposeRebalance(
+		context.Background(),
+		makeRebalanceReq(t, map[string]any{"include_forwarding_demand": true}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	require.Len(t, stub.fwdRequests, 2)
+	assert.Equal(t, uint32(0), stub.fwdRequests[0].IndexOffset)
+	assert.Equal(t, uint32(rebalanceHistoryPageSize), stub.fwdRequests[1].IndexOffset)
+
+	out := unmarshalResult(t, result)
+	analysis := out["analysis"].(map[string]any)
+	overLocal := analysis["over_local_channels"].([]any)
+	require.Len(t, overLocal, 1)
+	assert.Equal(t, float64(-(rebalanceHistoryPageSize + 1)),
+		overLocal[0].(map[string]any)["fwd_net_flow_sat"])
+}
+
+func TestRebalanceService_ForwardingHistoryError(t *testing.T) {
+	// A ForwardingHistory failure must not break the response.
+	stub := &stubRebalanceClient{
+		channels: []*lnrpc.Channel{
+			{
+				ChanId: 1, Capacity: 1_000_000,
+				LocalBalance: 800_000, RemoteBalance: 200_000,
+			},
+			{
+				ChanId: 2, Capacity: 1_000_000,
+				LocalBalance: 200_000, RemoteBalance: 800_000,
+			},
+		},
+		fwdErr: true,
+	}
+	svc := NewRebalanceService(stub)
+
+	result, err := svc.HandleProposeRebalance(
+		context.Background(),
+		makeRebalanceReq(t, map[string]any{"include_forwarding_demand": true}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "forwarding history error should degrade gracefully")
+
+	out := unmarshalResult(t, result)
+	candidates := out["candidates"].([]any)
+	require.Len(t, candidates, 1, "candidate still returned despite forwarding error")
+}
+
+func TestRebalanceService_MaxCandidatesRespected(t *testing.T) {
+	channels := make([]*lnrpc.Channel, 0, 6)
+	for i := uint64(1); i <= 3; i++ {
+		channels = append(channels, &lnrpc.Channel{
+			ChanId: i, Capacity: 1_000_000,
+			LocalBalance: 800_000, RemoteBalance: 200_000,
+		})
+	}
+	for i := uint64(4); i <= 6; i++ {
+		channels = append(channels, &lnrpc.Channel{
+			ChanId: i, Capacity: 1_000_000,
+			LocalBalance: 200_000, RemoteBalance: 800_000,
+		})
+	}
+	stub := &stubRebalanceClient{channels: channels}
+	svc := NewRebalanceService(stub)
+
+	result, err := svc.HandleProposeRebalance(
+		context.Background(),
+		makeRebalanceReq(t, map[string]any{
+			"max_candidates":            2,
+			"include_forwarding_demand": false,
+		}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := unmarshalResult(t, result)
+	candidates := out["candidates"].([]any)
+	assert.LessOrEqual(t, len(candidates), 2,
+		"max_candidates must be respected")
+}
+
+func TestRebalanceService_AnalysisFields(t *testing.T) {
+	stub := &stubRebalanceClient{
+		channels: []*lnrpc.Channel{
+			{ChanId: 1, Capacity: 1_000_000, LocalBalance: 800_000, RemoteBalance: 200_000},
+			{ChanId: 2, Capacity: 1_000_000, LocalBalance: 200_000, RemoteBalance: 800_000},
+			{ChanId: 3, Capacity: 1_000_000, LocalBalance: 500_000, RemoteBalance: 500_000},
+		},
+	}
+	svc := NewRebalanceService(stub)
+
+	result, err := svc.HandleProposeRebalance(
+		context.Background(),
+		makeRebalanceReq(t, map[string]any{"include_forwarding_demand": false}),
+	)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	out := unmarshalResult(t, result)
+	analysis, ok := out["analysis"].(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, float64(3), analysis["total_active_channels"])
+	overLocal := analysis["over_local_channels"].([]any)
+	overRemote := analysis["over_remote_channels"].([]any)
+	assert.Len(t, overLocal, 1)
+	assert.Len(t, overRemote, 1)
+
+	// Verify per-channel map fields.
+	ch := overLocal[0].(map[string]any)
+	assert.Contains(t, ch, "chan_id")
+	assert.Contains(t, ch, "local_balance")
+	assert.Contains(t, ch, "local_ratio")
+}

--- a/lightning-mcp-server/tools/tools_test.go
+++ b/lightning-mcp-server/tools/tools_test.go
@@ -251,6 +251,24 @@ func TestCreateTestInvoice(t *testing.T) {
 	assert.Equal(t, int64(3600), invoice.Expiry)
 }
 
+// Test HealthService basic functionality.
+func TestHealthService_ToolCreation(t *testing.T) {
+	service := NewHealthService(nil)
+
+	t.Run("node_health_tool", func(t *testing.T) {
+		tool := service.NodeHealthTool()
+		assert.Equal(t, "lnc_node_health", tool.Name)
+		assert.Contains(t, tool.Description, "health")
+		schema := requireToolSchema(t, tool.InputSchema)
+		assert.Equal(t, "object", schema.Type)
+	})
+
+	t.Run("service_management", func(t *testing.T) {
+		assert.NotNil(t, service)
+		assert.Nil(t, service.LightningClient)
+	})
+}
+
 // Benchmark tests for performance.
 func BenchmarkInvoiceService_ListInvoicesTool(b *testing.B) {
 	service := NewInvoiceService(nil)

--- a/lightning-mcp-server/tools/tools_test.go
+++ b/lightning-mcp-server/tools/tools_test.go
@@ -244,6 +244,33 @@ func createTestInvoice(amount int64, memo string) *lnrpc.Invoice {
 	}
 }
 
+func TestChannelActionsService_ToolCreation(t *testing.T) {
+	service := NewChannelActionsService(nil)
+
+	t.Run("propose_channel_actions_tool", func(t *testing.T) {
+		tool := service.ProposeChannelActionsTool()
+		assert.Equal(t, "lnc_propose_channel_actions", tool.Name)
+		assert.Contains(t, tool.Description, "Read-only")
+		schema := requireToolSchema(t, tool.InputSchema)
+		assert.Equal(t, "object", schema.Type)
+
+		props := schema.Properties
+		assert.Contains(t, props, "lookback_days")
+		assert.Contains(t, props, "max_close_candidates")
+		assert.Contains(t, props, "max_open_candidates")
+
+		lookbackField, ok := props["lookback_days"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "integer", lookbackField["type"])
+	})
+}
+
+func TestChannelActionsService_NilClient(t *testing.T) {
+	service := NewChannelActionsService(nil)
+	assert.NotNil(t, service)
+	assert.Nil(t, service.LightningClient)
+}
+
 func TestCreateTestInvoice(t *testing.T) {
 	invoice := createTestInvoice(1000, "test memo")
 	assert.Equal(t, int64(1000000), invoice.ValueMsat)

--- a/skills/macaroon-bakery/SKILL.md
+++ b/skills/macaroon-bakery/SKILL.md
@@ -20,6 +20,9 @@ skills/macaroon-bakery/scripts/bake.sh --role invoice-only
 # Bake a read-only macaroon
 skills/macaroon-bakery/scripts/bake.sh --role read-only
 
+# Bake a node-ops macaroon (fee management + circular self-pay)
+skills/macaroon-bakery/scripts/bake.sh --role node-ops
+
 # Inspect any macaroon
 skills/macaroon-bakery/scripts/bake.sh --inspect ~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
 
@@ -65,8 +68,9 @@ with `macaroon:generate` permission (typically admin.macaroon).
 | `pay-only` | Pay invoices, decode invoices, get node info | Create invoices, open channels, see balances |
 | `invoice-only` | Create invoices, lookup invoices, get node info | Pay, open channels, see wallet balance |
 | `read-only` | Get info, balances, list channels/peers/payments | Pay, create invoices, open/close channels |
-| `channel-admin` | All of read-only + open/close channels, connect peers | Pay invoices, create invoices |
+| `channel-admin` | All of read-only + open/close channels, connect peers | Pay invoices, create invoices, set fees |
 | `signer-only` | Sign transactions, derive keys (for remote signer) | Everything else |
+| `node-ops` | Set channel fees (`UpdateChannelPolicy`), circular self-pay for rebalancing (`SendToRouteV2`, `BuildRoute`), query routes, read node/channel state | Open/close channels, pay external invoices, create invoices |
 
 ## Baking Custom Macaroons
 
@@ -109,6 +113,40 @@ skills/macaroon-bakery/scripts/bake.sh --inspect <path-to-macaroon>
 # Inspect the admin macaroon to see full permissions
 skills/macaroon-bakery/scripts/bake.sh --inspect ~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
 ```
+
+## Node-Ops Macaroon
+
+The `node-ops` role is for automated routing agents that need to tune fees and
+rebalance channels without holding admin-level trust.
+
+**What it can do:**
+- Set channel routing fees (`UpdateChannelPolicy`)
+- Send circular self-payments for rebalancing (`BuildRoute` + `SendToRouteV2`)
+- Query routes for probing (`QueryRoutes`)
+- Read node state (info, balances, channels)
+
+**What it cannot do:**
+- Open or close channels
+- Pay external invoices (`SendPaymentSync` / `SendPaymentV2` are excluded)
+- Create invoices
+- Connect or disconnect peers
+
+```bash
+# Bake a node-ops macaroon (local node)
+skills/macaroon-bakery/scripts/bake.sh --role node-ops
+
+# Bake inside a litd container
+skills/macaroon-bakery/scripts/bake.sh --role node-ops --container litd
+
+# Verify what was baked
+skills/macaroon-bakery/scripts/bake.sh --inspect ~/.lnd/data/chain/bitcoin/testnet/node-ops.macaroon
+```
+
+The key difference from `channel-admin`: node-ops agents can set fees and
+self-pay for rebalancing but cannot open or close channels. The key difference
+from `pay-only`: node-ops agents can manage routing policy but cannot pay
+arbitrary external invoices — `SendToRouteV2` requires you to construct the
+exact route, making accidental external payments unlikely.
 
 ## Signer Macaroon Scoping
 
@@ -172,6 +210,11 @@ skills/lnd/scripts/lncli.sh bakemacaroon --root_key_id 0
 | `uri:/lnrpc.Lightning/ConnectPeer` | Connect to a peer |
 | `uri:/lnrpc.Lightning/OpenChannelSync` | Open a channel |
 | `uri:/lnrpc.Lightning/CloseChannel` | Close a channel |
+| `uri:/lnrpc.Lightning/UpdateChannelPolicy` | Set routing fees for channels |
+| `uri:/lnrpc.Lightning/QueryRoutes` | Query routes between nodes |
+| `uri:/routerrpc.Router/SendToRouteV2` | Send along an explicitly constructed route (circular self-pay) |
+| `uri:/routerrpc.Router/BuildRoute` | Build a route from a list of hops |
+| `uri:/routerrpc.Router/ResetMissionControl` | Reset payment attempt history |
 | `uri:/signrpc.Signer/SignOutputRaw` | Sign a transaction output |
 | `uri:/signrpc.Signer/ComputeInputScript` | Compute input script for signing |
 | `uri:/signrpc.Signer/MuSig2Sign` | MuSig2 signing |

--- a/skills/macaroon-bakery/SKILL.md
+++ b/skills/macaroon-bakery/SKILL.md
@@ -20,7 +20,7 @@ skills/macaroon-bakery/scripts/bake.sh --role invoice-only
 # Bake a read-only macaroon
 skills/macaroon-bakery/scripts/bake.sh --role read-only
 
-# Bake a node-ops macaroon (fee management + circular self-pay)
+# Bake a node-ops macaroon (fee management + route-send rebalancing)
 skills/macaroon-bakery/scripts/bake.sh --role node-ops
 
 # Inspect any macaroon
@@ -70,7 +70,7 @@ with `macaroon:generate` permission (typically admin.macaroon).
 | `read-only` | Get info, balances, list channels/peers/payments | Pay, create invoices, open/close channels |
 | `channel-admin` | All of read-only + open/close channels, connect peers | Pay invoices, create invoices, set fees |
 | `signer-only` | Sign transactions, derive keys (for remote signer) | Everything else |
-| `node-ops` | Set channel fees (`UpdateChannelPolicy`), circular self-pay for rebalancing (`SendToRouteV2`, `BuildRoute`), query routes, read node/channel state | Open/close channels, pay external invoices, create invoices |
+| `node-ops` | Set channel fees (`UpdateChannelPolicy`), build/query routes, use `SendToRouteV2` for daemon-checked rebalancing, read node/channel state | Open/close channels, create invoices, use high-level payment RPCs (`SendPaymentSync`, `SendPaymentV2`) |
 
 ## Baking Custom Macaroons
 
@@ -117,19 +117,28 @@ skills/macaroon-bakery/scripts/bake.sh --inspect ~/.lnd/data/chain/bitcoin/mainn
 ## Node-Ops Macaroon
 
 The `node-ops` role is for automated routing agents that need to tune fees and
-rebalance channels without holding admin-level trust.
+rebalance channels without holding admin-level trust. It is designed to be held
+by the governance daemon, not by a general-purpose agent.
+
+Important: lnd URI-scoped macaroons cannot express "self-pay only". This preset
+grants route construction and `SendToRouteV2`; the daemon or caller must enforce
+the circular route, payment hash, amount, fee, and peer boundaries before using
+those RPCs.
 
 **What it can do:**
 - Set channel routing fees (`UpdateChannelPolicy`)
-- Send circular self-payments for rebalancing (`BuildRoute` + `SendToRouteV2`)
+- Send along explicitly constructed routes for daemon-checked rebalancing
+  (`BuildRoute` + `SendToRouteV2`)
 - Query routes for probing (`QueryRoutes`)
 - Read node state (info, balances, channels)
 
 **What it cannot do:**
 - Open or close channels
-- Pay external invoices (`SendPaymentSync` / `SendPaymentV2` are excluded)
+- Use high-level payment RPCs (`SendPaymentSync` / `SendPaymentV2` are excluded)
 - Create invoices
 - Connect or disconnect peers
+- Reset mission control state (`ResetMissionControl` is excluded because it
+  mutates global pathfinding history)
 
 ```bash
 # Bake a node-ops macaroon (local node)
@@ -142,11 +151,11 @@ skills/macaroon-bakery/scripts/bake.sh --role node-ops --container litd
 skills/macaroon-bakery/scripts/bake.sh --inspect ~/.lnd/data/chain/bitcoin/testnet/node-ops.macaroon
 ```
 
-The key difference from `channel-admin`: node-ops agents can set fees and
-self-pay for rebalancing but cannot open or close channels. The key difference
-from `pay-only`: node-ops agents can manage routing policy but cannot pay
-arbitrary external invoices — `SendToRouteV2` requires you to construct the
-exact route, making accidental external payments unlikely.
+The key difference from `channel-admin`: node-ops agents can set fees and use
+route-send primitives for rebalancing but cannot open or close channels. The key
+difference from `pay-only`: node-ops excludes high-level invoice payment RPCs,
+but `SendToRouteV2` is still a payment primitive. Treat this macaroon as a
+daemon credential and enforce self-payment constraints in daemon logic.
 
 ## Signer Macaroon Scoping
 
@@ -212,7 +221,7 @@ skills/lnd/scripts/lncli.sh bakemacaroon --root_key_id 0
 | `uri:/lnrpc.Lightning/CloseChannel` | Close a channel |
 | `uri:/lnrpc.Lightning/UpdateChannelPolicy` | Set routing fees for channels |
 | `uri:/lnrpc.Lightning/QueryRoutes` | Query routes between nodes |
-| `uri:/routerrpc.Router/SendToRouteV2` | Send along an explicitly constructed route (circular self-pay) |
+| `uri:/routerrpc.Router/SendToRouteV2` | Send along an explicitly constructed route; callers must enforce self-payment constraints |
 | `uri:/routerrpc.Router/BuildRoute` | Build a route from a list of hops |
 | `uri:/routerrpc.Router/ResetMissionControl` | Reset payment attempt history |
 | `uri:/signrpc.Signer/SignOutputRaw` | Sign a transaction output |

--- a/skills/macaroon-bakery/scripts/bake.sh
+++ b/skills/macaroon-bakery/scripts/bake.sh
@@ -271,8 +271,12 @@ if [ -n "$ROLE" ]; then
             )
             ;;
         node-ops)
-            # Fee management + circular self-pay (rebalancing). Cannot open/close
-            # channels or pay external invoices — use channel-admin or pay-only for those.
+            # Fee management + route-send primitives for rebalancing. Cannot
+            # open/close channels or use high-level invoice payment RPCs.
+            # ResetMissionControl is excluded because it mutates global routing
+            # history outside a bounded fee/rebalance action.
+            # lnd macaroons cannot enforce "self-pay only"; daemon logic must
+            # validate route/payment boundaries before using SendToRouteV2.
             PERMS=(
                 "uri:/lnrpc.Lightning/GetInfo"
                 "uri:/lnrpc.Lightning/WalletBalance"
@@ -285,7 +289,6 @@ if [ -n "$ROLE" ]; then
                 "uri:/lnrpc.Lightning/QueryRoutes"
                 "uri:/routerrpc.Router/SendToRouteV2"
                 "uri:/routerrpc.Router/BuildRoute"
-                "uri:/routerrpc.Router/ResetMissionControl"
                 "uri:/verrpc.Versioner/GetVersion"
             )
             ;;

--- a/skills/macaroon-bakery/scripts/bake.sh
+++ b/skills/macaroon-bakery/scripts/bake.sh
@@ -97,7 +97,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --inspect PATH         Inspect a macaroon file"
             echo "  --list-permissions     List all available permission URIs"
             echo ""
-            echo "Preset roles: pay-only, invoice-only, read-only, channel-admin, signer-only"
+            echo "Preset roles: pay-only, invoice-only, read-only, channel-admin, signer-only, node-ops"
             echo ""
             echo "Options:"
             echo "  --save-to PATH         Output path (default: auto-generated)"
@@ -270,9 +270,28 @@ if [ -n "$ROLE" ]; then
                 "uri:/verrpc.Versioner/GetVersion"
             )
             ;;
+        node-ops)
+            # Fee management + circular self-pay (rebalancing). Cannot open/close
+            # channels or pay external invoices — use channel-admin or pay-only for those.
+            PERMS=(
+                "uri:/lnrpc.Lightning/GetInfo"
+                "uri:/lnrpc.Lightning/WalletBalance"
+                "uri:/lnrpc.Lightning/ChannelBalance"
+                "uri:/lnrpc.Lightning/ListChannels"
+                "uri:/lnrpc.Lightning/GetChanInfo"
+                "uri:/lnrpc.Lightning/GetNodeInfo"
+                "uri:/lnrpc.Lightning/UpdateChannelPolicy"
+                "uri:/lnrpc.Lightning/DecodePayReq"
+                "uri:/lnrpc.Lightning/QueryRoutes"
+                "uri:/routerrpc.Router/SendToRouteV2"
+                "uri:/routerrpc.Router/BuildRoute"
+                "uri:/routerrpc.Router/ResetMissionControl"
+                "uri:/verrpc.Versioner/GetVersion"
+            )
+            ;;
         *)
             echo "Error: Unknown role '$ROLE'." >&2
-            echo "Available roles: pay-only, invoice-only, read-only, channel-admin, signer-only" >&2
+            echo "Available roles: pay-only, invoice-only, read-only, channel-admin, signer-only, node-ops" >&2
             exit 1
             ;;
     esac


### PR DESCRIPTION
## Summary

- Adds a new `node-ops` preset to `skills/macaroon-bakery/scripts/bake.sh`
- Grants only `UpdateChannelPolicy` + router self-pay URIs (`BuildRoute`, `SendToRouteV2`, `QueryRoutes`, `ResetMissionControl`) plus read-only state permissions
- Excludes `OpenChannelSync`, `CloseChannel`, `SendPaymentSync`, `SendPaymentV2` — the preset cannot open/close channels or pay external invoices
- Documents the new role in `SKILL.md` (preset table, dedicated section, Common Permission URIs table)

Closes #7

## Permission set

| Included | Purpose |
|---|---|
| `UpdateChannelPolicy` | Set routing fees |
| `QueryRoutes` | Query available routes |
| `Router/BuildRoute` | Construct explicit circular route |
| `Router/SendToRouteV2` | Execute circular self-payment for rebalancing |
| `Router/ResetMissionControl` | Reset payment attempt history |
| `DecodePayReq` | Decode invoices needed for self-pay |
| `GetInfo`, `WalletBalance`, `ChannelBalance`, `ListChannels`, `GetChanInfo`, `GetNodeInfo` | Read node state |
| `GetVersion` | Version check |

| Excluded | Why |
|---|---|
| `SendPaymentSync` / `SendPaymentV2` | Would allow paying external invoices |
| `OpenChannelSync` / `CloseChannel` | Channel lifecycle — use `channel-admin` |
| `AddInvoice` | Not needed for fee/rebalance operations |
| `ConnectPeer` / `DisconnectPeer` | Peer management — use `channel-admin` |

## Test plan

- [ ] `bake.sh --role node-ops` bakes successfully and saves to `node-ops.macaroon`
- [ ] `bake.sh --inspect <path>/node-ops.macaroon` shows only the 13 listed URIs
- [ ] `bake.sh --help` lists `node-ops` in the preset roles line
- [ ] `lncli --macaroonpath node-ops.macaroon updatechanpolicy ...` succeeds (set fees)
- [ ] `lncli --macaroonpath node-ops.macaroon buildroute ...` + `sendtoroute` succeeds (self-pay)
- [ ] `lncli --macaroonpath node-ops.macaroon openchannel ...` fails with permission denied
- [ ] `lncli --macaroonpath node-ops.macaroon sendpayment ...` fails with permission denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)