### PR TITLE
plugin: fix repository field type breaking plugin install

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,8 +5,5 @@
   "author": {
     "name": "Lightning Labs"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/lightninglabs/lightning-agent-kit"
-  }
+  "repository": "https://github.com/lightninglabs/lightning-agent-tools"
 }


### PR DESCRIPTION
Installing the plugin per the README's Option B fails on a clean machine:

    $ claude plugin marketplace add lightninglabs/lightning-agent-tools
    ✔ Successfully added marketplace: lightninglabs
    $ claude plugin install lightning-agent-tools@lightninglabs
    ✘ Failed to install plugin "lightning-agent-tools@lightninglabs": Plugin ... has an
      invalid manifest file at .../.claude-plugin/plugin.json.
      Validation errors: repository: Invalid input: expected string, received object

Reproduced on latest Claude Code (2.1.215).

**Root cause:** [Claude Code plugin manifest schema](https://code.claude.com/docs/en/plugins-reference) requires
`repository` to be a plain string (`author` as an object is fine). The
mismatch isn't caught by `claude plugin marketplace add`, which only
validates `marketplace.json` (whose entry-level `repository` is already a
string) — the plugin's own `plugin.json` is only schema-validated at install
time, so every `claude plugin install` hits it.

While here: the object's URL still pointed at the pre-rename
`lightning-agent-kit` repo; the fix uses the current `lightning-agent-tools`
URL, matching `marketplace.json`.

**Verification:**

    $ claude plugin marketplace add <repo-with-this-fix>
    ✔ Successfully added marketplace: lightninglabs
    $ claude plugin install lightning-agent-tools@lightninglabs
    ✔ Successfully installed plugin: lightning-agent-tools@lightninglabs (scope: user)

Note for users who previously added the marketplace: the marketplace cache
is a clone, so after this merge an existing setup needs
`claude plugin marketplace update lightninglabs` (or remove/re-add) before
install picks up the fixed manifest. Fresh installs are unaffected.